### PR TITLE
feat: Add device and OS version info to connection logs

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/util/DeviceInfo.kt
+++ b/app/src/main/java/com/example/vitruvianredux/util/DeviceInfo.kt
@@ -1,0 +1,85 @@
+package com.example.vitruvianredux.util
+
+import android.os.Build
+
+/**
+ * Device information utility for logging and debugging
+ */
+object DeviceInfo {
+
+    /**
+     * Get device manufacturer (e.g., "samsung", "Google")
+     */
+    val manufacturer: String = Build.MANUFACTURER
+
+    /**
+     * Get device model (e.g., "SM-G998U" for S21 Ultra)
+     */
+    val model: String = Build.MODEL
+
+    /**
+     * Get device name (e.g., "Galaxy S21 Ultra 5G")
+     */
+    val device: String = Build.DEVICE
+
+    /**
+     * Get Android version string (e.g., "12", "13")
+     */
+    val androidVersion: String = Build.VERSION.RELEASE
+
+    /**
+     * Get Android SDK level (e.g., 31 for Android 12)
+     */
+    val sdkInt: Int = Build.VERSION.SDK_INT
+
+    /**
+     * Get full Android version string with SDK level
+     */
+    val androidVersionFull: String = "Android $androidVersion (SDK $sdkInt)"
+
+    /**
+     * Get device fingerprint (unique build ID)
+     */
+    val fingerprint: String = Build.FINGERPRINT
+
+    /**
+     * Get a formatted device info string for logging
+     */
+    fun getFormattedInfo(): String {
+        return buildString {
+            appendLine("Device: $manufacturer $model")
+            appendLine("Model Name: $device")
+            appendLine("OS: $androidVersionFull")
+            appendLine("Build: ${Build.DISPLAY}")
+        }
+    }
+
+    /**
+     * Get a compact one-line device description
+     */
+    fun getCompactInfo(): String {
+        return "$manufacturer $model (Android $androidVersion, SDK $sdkInt)"
+    }
+
+    /**
+     * Get device info as structured JSON string for metadata storage
+     */
+    fun toJson(): String {
+        return """{"manufacturer":"$manufacturer","model":"$model","device":"$device","androidVersion":"$androidVersion","sdkInt":$sdkInt,"fingerprint":"$fingerprint"}"""
+    }
+
+    /**
+     * Check if running on Android 12 or higher (new BLE permissions)
+     */
+    fun isAndroid12OrHigher(): Boolean = sdkInt >= Build.VERSION_CODES.S
+
+    /**
+     * Check if running on Samsung device
+     */
+    fun isSamsung(): Boolean = manufacturer.equals("samsung", ignoreCase = true)
+
+    /**
+     * Check if running on Google Pixel
+     */
+    fun isPixel(): Boolean = manufacturer.equals("Google", ignoreCase = true)
+}


### PR DESCRIPTION
Captures and logs both Android device and Vitruvian machine information to provide critical debugging context for BLE connectivity issues.

**Android Device Information:**
- Device manufacturer (e.g., "samsung", "Google")
- Device model (e.g., "SM-G998U" for S21 Ultra)
- Android version (e.g., "Android 12 (SDK 31)")
- Device fingerprint (unique build ID)
- Logged once at app startup as SYSTEM_INFO event
- Included in every CONNECTION_SUCCESS event

**Vitruvian Machine Information:**
- Device name (e.g., "Vee123")
- MAC address
- Inferred model (V1/V1+ based on naming convention)
- Note about firmware version not being available via BLE
- Logged as VITRUVIAN_DEVICE_INFO on successful connection

**Enhanced Export Format:**
Exported logs now include a structured header with:
```
═══════════════════════════════════════════════════════
       VITRUVIAN CONNECTION DEBUG LOG EXPORT
═══════════════════════════════════════════════════════

Generated: 2025-01-15 14:30:00
Total entries: 234

─── Android Device Information ───
Device: samsung SM-G998U
Model Name: o1q
OS: Android 12 (SDK 31)
Build: SP1A.210812.016

─── Vitruvian Trainer Information ───
Device Name: Vee123
MAC Address: AA:BB:CC:DD:EE:FF
Model: Vitruvian V1/V1+ (Vee123)

Note: Firmware version not available via BLE
To check firmware: Settings → About on Vitruvian touchscreen

═══════════════════════════════════════════════════════
                    EVENT LOG
═══════════════════════════════════════════════════════
```

**Why This Matters:**
BLE behavior varies significantly between:
- Android versions (esp. Android 12+ with new permissions)
- Device manufacturers (Samsung, Google, etc.)
- Different Vitruvian hardware revisions

This context will help correlate issues with specific device/OS/machine combinations, making it much easier to diagnose Issue #18 and similar problems.

**Utility Added:**
Created DeviceInfo utility with helpers for:
- Formatted device info strings
- Compact one-line descriptions
- JSON serialization for metadata storage
- Version checks (isAndroid12OrHigher)
- Manufacturer detection (isSamsung, isPixel)

Related to #18