### PR TITLE
fix: Fix sets not progressing properly (Issue #19)

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/SingleExerciseScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/SingleExerciseScreen.kt
@@ -100,23 +100,22 @@ fun SingleExerciseScreen(
                     exerciseRepository = exerciseRepository,
                     buttonText = "Start Workout",
                     onSave = { configuredExercise ->
-                        val parameters = WorkoutParameters(
-                            workoutType = configuredExercise.workoutType,
-                            reps = configuredExercise.setReps.firstOrNull() ?: 10,
-                            weightPerCableKg = configuredExercise.weightPerCableKg,
-                            progressionRegressionKg = configuredExercise.progressionKg,
-                            isJustLift = false,
-                            stopAtTop = false,
-                            warmupReps = 3,
-                            selectedExerciseId = configuredExercise.exercise.id
+                        // Create a temporary single-exercise routine for proper multi-set support
+                        // This ensures rest timers work and sets progress correctly
+                        val tempRoutine = Routine(
+                            id = "temp_single_exercise_${UUID.randomUUID()}",
+                            name = "Single Exercise: ${configuredExercise.exercise.name}",
+                            description = "Temporary routine for single exercise mode",
+                            exercises = listOf(configuredExercise)
                         )
 
-                        viewModel.updateWorkoutParameters(parameters)
+                        // Load the routine (this sets up all the multi-set tracking)
+                        viewModel.loadRoutine(tempRoutine)
 
                         viewModel.ensureConnection(
                             onConnected = {
                                 viewModel.startWorkout()
-                                navController.navigate(NavigationRoutes.ActiveWorkout.route) { 
+                                navController.navigate(NavigationRoutes.ActiveWorkout.route) {
                                     popUpTo(NavigationRoutes.Home.route) // Clear back stack to home
                                 }
                             },


### PR DESCRIPTION
Fixes the issue where completing a set would immediately end the workout instead of showing a rest timer and allowing progression to the next set.

**Root Causes Identified:**

1. **Single Exercise Mode Issue:**
   - Single Exercise created RoutineExercise with multiple sets
   - But only used first set's reps and didn't load as a routine
   - Result: routine == null → went straight to Completed

2. **Autoplay Dependency:**
   - Rest timer only showed if routine != null AND autoplay enabled
   - Users with autoplay disabled never saw rest timers
   - This was wrong - rest timers should always show when more sets remain

**Changes Made:**

1. **SingleExerciseScreen.kt**:
   - Now creates temporary single-exercise Routine
   - Calls viewModel.loadRoutine() instead of just updateWorkoutParameters()
   - This enables full multi-set support with rest timers

2. **MainViewModel.kt - handleSetCompletion()**:
   - Removed dependency on autoplay for showing rest timer
   - Now checks if there are more sets OR exercises remaining
   - Shows rest timer whenever shouldShowRestTimer is true
   - Logic: `(hasMoreSets || hasMoreExercises) && !isJustLift`

3. **MainViewModel.kt - startRestTimer()**:
   - Now respects autoplay preference for auto-advance behavior
   - If autoplay enabled: counts down → auto-advances to next set
   - If autoplay disabled: counts down → stays at 0 seconds → waits for user
   - User can manually advance via "Skip Rest" / "Start Next Set" button

**Behavior After Fix:**

| Mode | Sets | Autoplay | Result |
|------|------|----------|---------|
| Single Exercise | 3 sets | On/Off | ✅ Shows rest timer, progresses through all 3 sets | | Routine | Multiple | On | ✅ Auto-advances after rest timer | | Routine | Multiple | Off | ✅ Shows rest timer, waits for manual "Start Next Set" | | Just Lift | Any | Any | ✅ No rest timer (by design), auto-resets |

**Testing Notes:**
- Single Exercise with 3 sets now works correctly
- Routines with autoplay off now show rest timers
- Just Lift mode unchanged (no rest timers, immediate reset)
- Skip Rest button still works correctly

Fixes #19