### PR TITLE
fix: Add ConnectingOverlay modal to Settings screen

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavGraph.kt
@@ -113,6 +113,8 @@ fun NavGraph(
         composable(NavigationRoutes.Settings.route) {
             val weightUnit by viewModel.weightUnit.collectAsState()
             val userPreferences by viewModel.userPreferences.collectAsState()
+            val isAutoConnecting by viewModel.isAutoConnecting.collectAsState()
+            val connectionError by viewModel.connectionError.collectAsState()
             SettingsTab(
                 weightUnit = weightUnit,
                 autoplayEnabled = userPreferences.autoplayEnabled,
@@ -120,7 +122,10 @@ fun NavGraph(
                 onAutoplayChange = { viewModel.setAutoplayEnabled(it) },
                 onColorSchemeChange = { viewModel.setColorScheme(it) },
                 onDeleteAllWorkouts = { viewModel.deleteAllWorkouts() },
-                onNavigateToConnectionLogs = { navController.navigate(NavigationRoutes.ConnectionLogs.route) }
+                onNavigateToConnectionLogs = { navController.navigate(NavigationRoutes.ConnectionLogs.route) },
+                isAutoConnecting = isAutoConnecting,
+                connectionError = connectionError,
+                onClearConnectionError = { viewModel.clearConnectionError() }
             )
         }
 

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
@@ -318,6 +318,9 @@ fun SettingsTab(
     onColorSchemeChange: (Int) -> Unit,
     onDeleteAllWorkouts: () -> Unit,
     onNavigateToConnectionLogs: () -> Unit = {},
+    isAutoConnecting: Boolean = false,
+    connectionError: String? = null,
+    onClearConnectionError: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var showDeleteAllDialog by remember { mutableStateOf(false) }
@@ -725,6 +728,18 @@ fun SettingsTab(
                     Text("Cancel", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
+        )
+    }
+
+    // Auto-connect UI overlays (same as other screens)
+    if (isAutoConnecting) {
+        com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+    }
+
+    connectionError?.let { error ->
+        com.example.vitruvianredux.presentation.components.ConnectionErrorDialog(
+            message = error,
+            onDismiss = onClearConnectionError
         )
     }
 }


### PR DESCRIPTION
Completes fix for issue #25 by adding the ConnectingOverlay modal to the Settings screen, which was missed in the initial fix.

Changes:
- Added isAutoConnecting, connectionError, and onClearConnectionError parameters to SettingsTab composable with default values
- Added ConnectingOverlay and ConnectionErrorDialog components to SettingsTab
- Updated NavGraph to pass connection state to SettingsTab from MainViewModel

The modal now appears consistently on ALL screens including Settings when the user clicks the Bluetooth icon to connect.