### PR TITLE
fix: Release resistance when manually stopping workout

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/data/repository/BleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/repository/BleRepositoryImpl.kt
@@ -439,10 +439,10 @@ class BleRepositoryImpl @Inject constructor(
 
     override suspend fun stopWorkout(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
-            // Send stop command (init command stops current workout)
-            bleManager?.sendCommand(ProtocolBuilder.buildInitCommand())?.getOrThrow()
+            // Send stop command to release resistance
+            bleManager?.sendCommand(ProtocolBuilder.buildStopCommand())?.getOrThrow()
 
-            Timber.d("Workout stopped")
+            Timber.d("Workout stopped - resistance released")
             Result.success(Unit)
         } catch (e: Exception) {
             Timber.e(e, "Failed to stop workout")


### PR DESCRIPTION
Fixes #31

Changed stopWorkout() to send the proper STOP command (0x05) instead of INIT command (0x0A) to ensure equipment resistance is properly released when user manually stops the workout.

This addresses a critical safety issue where resistance remained engaged after stopping a workout through the UI.