### PR TITLE
Resolve GitHub Issue #38 in VitruvianProjectPhoenix

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/EnhancedMainScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/EnhancedMainScreen.kt
@@ -302,12 +302,12 @@ fun EnhancedMainScreen(
             }
         }
     ) { padding ->
-        // Remove top padding to eliminate gap since nested screens have their own TopAppBars
+        // Use proper padding to account for TopAppBar and system bars (status bar, notch, etc.)
         val layoutDirection = androidx.compose.ui.platform.LocalLayoutDirection.current
         val adjustedPadding = PaddingValues(
             start = padding.calculateLeftPadding(layoutDirection),
             end = padding.calculateRightPadding(layoutDirection),
-            top = 0.dp,
+            top = padding.calculateTopPadding(),
             bottom = padding.calculateBottomPadding()
         )
 


### PR DESCRIPTION
Fixed issue #38 where the top portion of the screen was being cut off on all pages, particularly noticeable on the Settings page.

The root cause was that EnhancedMainScreen.kt was explicitly setting top padding to 0.dp, which caused content to render under the TopAppBar and system bars (status bar, notch areas, etc.).

Changed from `top = 0.dp` to `top = padding.calculateTopPadding()` to properly respect the system window insets and TopAppBar height.

This ensures all screen content is properly positioned below the TopAppBar and system UI elements.