### PR TITLE
Fix routine duplication removing exercises from original

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/RoutinesTab.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/RoutinesTab.kt
@@ -114,7 +114,10 @@ fun RoutinesTab(
                                     name = "${routine.name} (Copy)",
                                     createdAt = System.currentTimeMillis(),
                                     useCount = 0,
-                                    lastUsed = null
+                                    lastUsed = null,
+                                    exercises = routine.exercises.map {
+                                        it.copy(id = java.util.UUID.randomUUID().toString())
+                                    }
                                 )
                                 onSaveRoutine(duplicated)
                             }


### PR DESCRIPTION
When duplicating a routine, the shallow copy was causing both routines to share the same exercise objects with identical IDs. This led to database conflicts where exercises would appear to move from the original routine to the duplicated one.

The fix deep copies the exercises list and generates new UUIDs for each exercise in the duplicated routine, ensuring complete isolation between the original and duplicate.

Fixes issue reported on Reddit where duplicating a routine removed exercises from the original.