### PR TITLE
Resolve GitHub Issue #56 in VitruvianProjectPhoenix

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/domain/model/Models.kt
+++ b/app/src/main/java/com/example/vitruvianredux/domain/model/Models.kt
@@ -191,7 +191,7 @@ data class WorkoutMetric(
 data class RepCount(
     val warmupReps: Int = 0,
     val workingReps: Int = 0,
-    val totalReps: Int = warmupReps + workingReps,
+    val totalReps: Int = workingReps,  // Exclude warm-up reps from total count
     val isWarmupComplete: Boolean = false
 )
 

--- a/app/src/main/java/com/example/vitruvianredux/domain/usecase/RepCounterFromMachine.kt
+++ b/app/src/main/java/com/example/vitruvianredux/domain/usecase/RepCounterFromMachine.kt
@@ -221,7 +221,7 @@ class RepCounterFromMachine {
     }
 
     fun getRepCount(): RepCount {
-        val total = warmupReps + workingReps
+        val total = workingReps  // Exclude warm-up reps from total count
         return RepCount(
             warmupReps = warmupReps,
             workingReps = workingReps,

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -1182,7 +1182,7 @@ class MainViewModel @Inject constructor(
             weightPerCableKg = actualPerCableWeightKg, // Store per-cable weight
             progressionKg = params.progressionRegressionKg,
             duration = duration,
-            totalReps = warmup + working,
+            totalReps = working,  // Exclude warm-up reps from total count
             warmupReps = warmup,
             workingReps = working,
             isJustLift = params.isJustLift,

--- a/app/src/test/java/com/example/vitruvianredux/integration/WorkoutIntegrationTest.kt
+++ b/app/src/test/java/com/example/vitruvianredux/integration/WorkoutIntegrationTest.kt
@@ -115,7 +115,7 @@ class WorkoutIntegrationTest {
             weightPerCableKg = 15.0f,
             progressionKg = 0f,
             duration = 5000L,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 10,
             isJustLift = false,
@@ -287,7 +287,7 @@ class WorkoutIntegrationTest {
                 weightPerCableKg = 15.0f + index * 2.5f,
                 progressionKg = 0f,
                 duration = 300000L + index * 60000L,
-                totalReps = 13 + index,
+                totalReps = 10 + index,  // Exclude warm-up reps from total count
                 warmupReps = 3,
                 workingReps = 10 + index,
                 isJustLift = false,
@@ -365,7 +365,7 @@ class WorkoutIntegrationTest {
                 weightPerCableKg = 15.0f,
                 progressionKg = 0f,
                 duration = 300000L,
-                totalReps = 13,
+                totalReps = 10,  // Exclude warm-up reps from total count
                 warmupReps = 3,
                 workingReps = 10,
                 isJustLift = false,
@@ -423,7 +423,7 @@ class WorkoutIntegrationTest {
             weightPerCableKg = 20.0f,
             progressionKg = 0f,
             duration = 450000L,
-            totalReps = 18,
+            totalReps = 15,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 15,
             isJustLift = false,
@@ -514,7 +514,7 @@ class WorkoutIntegrationTest {
             weightPerCableKg = 15.0f,
             progressionKg = 0f,
             duration = 300000L,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 10,
             isJustLift = false,

--- a/app/src/test/java/com/example/vitruvianredux/offline/OfflineFunctionalityTest.kt
+++ b/app/src/test/java/com/example/vitruvianredux/offline/OfflineFunctionalityTest.kt
@@ -96,7 +96,7 @@ class OfflineFunctionalityTest {
             weightPerCableKg = 15.0f,
             progressionKg = 0f,
             duration = 5000L,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 10,
             isJustLift = false,
@@ -160,7 +160,7 @@ class OfflineFunctionalityTest {
                 weightPerCableKg = 15.0f + index * 2.5f,
                 progressionKg = 0f,
                 duration = 300000L + index * 60000L,
-                totalReps = 13 + index,
+                totalReps = 10 + index,  // Exclude warm-up reps from total count
                 warmupReps = 3,
                 workingReps = 10 + index,
                 isJustLift = false,
@@ -236,7 +236,7 @@ class OfflineFunctionalityTest {
             weightPerCableKg = 20.0f,
             progressionKg = 0f,
             duration = 450000L,
-            totalReps = 18,
+            totalReps = 15,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 15,
             isJustLift = false,
@@ -258,14 +258,14 @@ class OfflineFunctionalityTest {
         val repCount = RepCount(
             warmupReps = 3,
             workingReps = 10,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             isWarmupComplete = true
         )
 
         // When: Calculating rep progress locally
         val warmupProgress = repCount.warmupReps / 3.0f
         val workingProgress = repCount.workingReps / 10.0f
-        val totalProgress = repCount.totalReps / 13.0f
+        val totalProgress = repCount.totalReps / 10.0f  // Total now excludes warm-up reps
 
         // Then: All calculations are local
         assertEquals(1.0f, warmupProgress, 0.01f, "Warmup progress calculated locally")
@@ -316,7 +316,7 @@ class OfflineFunctionalityTest {
                 weightPerCableKg = 15.0f + index * 0.5f,
                 progressionKg = 0f,
                 duration = 300000L,
-                totalReps = 13,
+                totalReps = 10,  // Exclude warm-up reps from total count
                 warmupReps = 3,
                 workingReps = 10,
                 isJustLift = false,
@@ -404,7 +404,7 @@ class OfflineFunctionalityTest {
                 weightPerCableKg = 18.0f,
                 progressionKg = 2.5f,
                 duration = 360000L,
-                totalReps = 15,
+                totalReps = 12,  // Exclude warm-up reps from total count
                 warmupReps = 3,
                 workingReps = 12,
                 isJustLift = false,
@@ -438,7 +438,7 @@ class OfflineFunctionalityTest {
             weightPerCableKg = 20.0f,
             progressionKg = 0f,
             duration = 450000L,
-            totalReps = 18,
+            totalReps = 15,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 15,
             isJustLift = false,

--- a/app/src/test/java/com/example/vitruvianredux/repository/WorkoutRepositoryTest.kt
+++ b/app/src/test/java/com/example/vitruvianredux/repository/WorkoutRepositoryTest.kt
@@ -51,7 +51,7 @@ class WorkoutRepositoryTest {
             weightPerCableKg = 15.0f,
             progressionKg = 0f,
             duration = 300000L,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 10,
             isJustLift = false,
@@ -196,7 +196,7 @@ class WorkoutRepositoryTest {
             weightPerCableKg = 20.0f,
             progressionKg = 2.5f,
             duration = 600000L,
-            totalReps = 18,
+            totalReps = 15,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 15,
             isJustLift = false,
@@ -264,7 +264,7 @@ class WorkoutRepositoryTest {
             weightPerCableKg = 15.0f,
             progressionKg = 0f,
             duration = 300000L,
-            totalReps = reps + 3,
+            totalReps = reps,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = reps,
             isJustLift = false,

--- a/app/src/test/java/com/example/vitruvianredux/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/example/vitruvianredux/ui/MainViewModelTest.kt
@@ -87,13 +87,13 @@ class MainViewModelTest {
         val repCount = RepCount(
             warmupReps = 3,
             workingReps = 10,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             isWarmupComplete = true
         )
 
         assertEquals(3, repCount.warmupReps)
         assertEquals(10, repCount.workingReps)
-        assertEquals(13, repCount.totalReps)
+        assertEquals(10, repCount.totalReps)  // Total should exclude warm-up reps
         assertTrue(repCount.isWarmupComplete)
     }
 
@@ -193,7 +193,7 @@ class MainViewModelTest {
             weightPerCableKg = 15.0f,
             progressionKg = 0f,
             duration = 300000L,
-            totalReps = 13,
+            totalReps = 10,  // Exclude warm-up reps from total count
             warmupReps = 3,
             workingReps = 10,
             isJustLift = false,


### PR DESCRIPTION
Modified rep counting logic to exclude warm-up repetitions from the total rep count. The totalReps field now only includes working reps, making it easier to track actual working set performance without warm-ups inflating the numbers.

Changes:
- RepCount model: totalReps now equals workingReps only
- RepCounterFromMachine: Updated getRepCount() to exclude warm-ups
- MainViewModel: Modified saveWorkoutSession() to save only working reps as total
- Updated all test files to reflect new totalReps calculation

Fixes #56