### PR TITLE
Resolve GitHub Issue #58 in VitruvianProjectPhoenix

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -123,7 +123,7 @@ class ExerciseConfigViewModel @Inject constructor() : ViewModel() {
         _sets.value = initialSets
 
         _selectedMode.value = exercise.workoutType.toWorkoutMode()
-        _weightChange.value = 0
+        _weightChange.value = kgToDisplay(exercise.progressionKg, weightUnit).toInt()
         _rest.value = exercise.restSeconds.coerceIn(0, 300)
         _notes.value = exercise.notes
         _eccentricLoad.value = exercise.eccentricLoad


### PR DESCRIPTION
Fixed issue where negative weight values (regression) were not being retained when editing an exercise in Old School mode. The bug was in ExerciseConfigViewModel where the weightChange value was always initialized to 0 instead of loading the existing progressionKg value from the exercise.

Changes:
- Initialize _weightChange from exercise.progressionKg instead of hardcoding to 0
- Convert from kg to display unit to maintain unit consistency

Fixes #58