### PR TITLE
Fix version display in Settings to show Beta 3

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
@@ -759,8 +759,8 @@ fun SettingsTab(
                 )
             }
                 Spacer(modifier = Modifier.height(Spacing.small))
-                Text("Version: 0.1.0-beta", color = MaterialTheme.colorScheme.onSurface)
-                Text("Build: Beta 1", color = MaterialTheme.colorScheme.onSurface)
+                Text("Version: 0.3.0-beta", color = MaterialTheme.colorScheme.onSurface)
+                Text("Build: Beta 3", color = MaterialTheme.colorScheme.onSurface)
                 Spacer(modifier = Modifier.height(Spacing.small))
                 Text(
                     "Open source community project to control Vitruvian Trainer machines locally.",


### PR DESCRIPTION
The Build information in the Settings tab was displaying "Beta 1" even though the actual app version is 0.3.0-beta (Beta 3). This was a hardcoded string that needed to be updated to match the versionName in build.gradle.kts.

Fixes #65