### PR TITLE
Fix invisible countdown timer numbers in light mode

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/CountdownCard.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/CountdownCard.kt
@@ -71,7 +71,7 @@ fun CountdownCard(secondsRemaining: Int) {
                     text = "$secondsRemaining",
                     style = MaterialTheme.typography.displayLarge.copy(fontSize = 96.sp),
                     fontWeight = FontWeight.ExtraBold,
-                    color = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             }
 

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/RestTimerCard.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/RestTimerCard.kt
@@ -129,7 +129,7 @@ fun RestTimerCard(
                             text = formatRestTime(restSecondsRemaining),
                             style = MaterialTheme.typography.displayLarge,
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary
+                            color = MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }


### PR DESCRIPTION
The countdown timer and rest timer numbers were invisible in light mode due to poor contrast. Light purple (primary color #E0BBF7) was being displayed on light backgrounds, creating a contrast ratio of ~1.5:1.

Changed timer text color from MaterialTheme.colorScheme.primary to MaterialTheme.colorScheme.onSurface in both CountdownCard.kt and RestTimerCard.kt. This ensures proper contrast in both light and dark modes by using semantic colors designed for text on backgrounds.

Fixes #66