### PR TITLE
Add rep/position bars for real-time cable position visualization

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
@@ -28,6 +28,7 @@ fun ActiveWorkoutScreen(
     val currentMetric by viewModel.currentMetric.collectAsState()
     val workoutParameters by viewModel.workoutParameters.collectAsState()
     val repCount by viewModel.repCount.collectAsState()
+    val repRanges by viewModel.repRanges.collectAsState()
     val autoStopState by viewModel.autoStopState.collectAsState()
     val weightUnit by viewModel.weightUnit.collectAsState()
     val loadedRoutine by viewModel.loadedRoutine.collectAsState()
@@ -123,6 +124,7 @@ fun ActiveWorkoutScreen(
             currentMetric = currentMetric,
             workoutParameters = workoutParameters,
             repCount = repCount,
+            repRanges = repRanges,
             autoStopState = autoStopState,
             weightUnit = weightUnit,
             exerciseRepository = exerciseRepository,

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/WorkoutTab.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/WorkoutTab.kt
@@ -45,6 +45,7 @@ fun WorkoutTab(
     currentMetric: WorkoutMetric?,
     workoutParameters: WorkoutParameters,
     repCount: RepCount,
+    repRanges: com.example.vitruvianredux.domain.usecase.RepRanges?,
     autoStopState: AutoStopUiState,
     weightUnit: WeightUnit,
     exerciseRepository: ExerciseRepository,
@@ -285,6 +286,14 @@ fun WorkoutTab(
                 is WorkoutState.Active -> {
                     // Show rep counter first (above video) so it's always visible
                     RepCounterCard(repCount = repCount, workoutParameters = workoutParameters)
+
+                    // Show position bars for visual feedback of machine response
+                    if (currentMetric != null) {
+                        PositionBarsCard(
+                            currentMetric = currentMetric,
+                            repRanges = repRanges
+                        )
+                    }
 
                     // Show current exercise details
                     CurrentExerciseCard(
@@ -1529,6 +1538,145 @@ fun LiveMetricsCard(
                         .height(8.dp)
                 )
             }
+        }
+    }
+}
+
+/**
+ * Position Bars Card - Shows real-time cable positions within calibrated range
+ * This provides visual feedback that the machine is responding and helps with setup
+ */
+@Composable
+fun PositionBarsCard(
+    currentMetric: WorkoutMetric,
+    repRanges: com.example.vitruvianredux.domain.usecase.RepRanges?
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.1f))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.medium)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Cable Position",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                if (repRanges != null && repRanges.rangeA != null) {
+                    Text(
+                        "Range: ${repRanges.rangeA}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(Spacing.medium))
+
+            // Cable A Position Bar
+            CablePositionBar(
+                label = "Cable A",
+                currentPosition = currentMetric.positionA,
+                minPosition = repRanges?.minPosA,
+                maxPosition = repRanges?.maxPosA,
+                isActive = currentMetric.positionA > 0
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.small))
+
+            // Cable B Position Bar
+            CablePositionBar(
+                label = "Cable B",
+                currentPosition = currentMetric.positionB,
+                minPosition = repRanges?.minPosB,
+                maxPosition = repRanges?.maxPosB,
+                isActive = currentMetric.positionB > 0
+            )
+
+            // Setup hint (only show when calibration is in progress)
+            if (repRanges == null || repRanges.rangeA == null || (repRanges.rangeA ?: 0) < 50) {
+                Spacer(modifier = Modifier.height(Spacing.small))
+                Text(
+                    "Perform a few reps to calibrate range",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Individual cable position bar with calibrated range visualization
+ */
+@Composable
+fun CablePositionBar(
+    label: String,
+    currentPosition: Int,
+    minPosition: Int?,
+    maxPosition: Int?,
+    isActive: Boolean
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                currentPosition.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (isActive) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Position bar with calibrated range
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            // Calculate progress within calibrated range
+            val progress = if (minPosition != null && maxPosition != null && maxPosition > minPosition) {
+                ((currentPosition - minPosition).toFloat() / (maxPosition - minPosition).toFloat()).coerceIn(0f, 1f)
+            } else {
+                // Fallback: use absolute position (0-1000 range typically)
+                (currentPosition / 1000f).coerceIn(0f, 1f)
+            }
+
+            // Filled portion showing current position
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(progress)
+                    .background(
+                        if (isActive) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        }
+                    )
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -76,6 +76,9 @@ class MainViewModel @Inject constructor(
     private val _repCount = MutableStateFlow(RepCount())
     val repCount: StateFlow<RepCount> = _repCount.asStateFlow()
 
+    private val _repRanges = MutableStateFlow<com.example.vitruvianredux.domain.usecase.RepRanges?>(null)
+    val repRanges: StateFlow<com.example.vitruvianredux.domain.usecase.RepRanges?> = _repRanges.asStateFlow()
+
     private val _autoStopState = MutableStateFlow(AutoStopUiState())
     val autoStopState: StateFlow<AutoStopUiState> = _autoStopState.asStateFlow()
 
@@ -460,6 +463,8 @@ class MainViewModel @Inject constructor(
             posA = currentPositions?.positionA ?: 0,
             posB = currentPositions?.positionB ?: 0
         )
+        // Update rep ranges for position bars visualization
+        _repRanges.value = repCounter.getRepRanges()
         // All other logic (UI update, haptics, auto-stop) handled in onRepEvent callback
     }
 
@@ -1300,6 +1305,7 @@ class MainViewModel @Inject constructor(
     fun resetForNewWorkout() {
         _workoutState.value = WorkoutState.Idle
         _repCount.value = RepCount()
+        _repRanges.value = null
         _currentSetIndex.value = 0
         resetAutoStopState()
         Timber.d("Reset for new workout - state returned to Idle")


### PR DESCRIPTION
This implements visual position bars that show real-time cable positions during active workouts, helping users:
- See that the machine is responding and tracking movement
- Calibrate their range of motion during setup reps
- Visualize cable extension within the calibrated min/max range

Implementation details:
- Added repRanges StateFlow to MainViewModel to expose calibrated position data
- Created PositionBarsCard component showing Cable A and Cable B positions
- Each bar displays current position within calibrated range
- Progress bars fill based on normalized position (min to max range)
- Shows "Perform a few reps to calibrate range" hint during initial setup
- Bars update in real-time as position data arrives from device

The position bars appear in the active workout screen, positioned between the rep counter and exercise details for optimal visibility.

Fixes #1 - Missing Rep/Position Bars