### PR TITLE
Add post-set summary screen with detailed performance metrics

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/domain/model/Models.kt
+++ b/app/src/main/java/com/example/vitruvianredux/domain/model/Models.kt
@@ -31,6 +31,12 @@ sealed class WorkoutState {
     object Initializing : WorkoutState()
     data class Countdown(val secondsRemaining: Int) : WorkoutState()
     object Active : WorkoutState()
+    data class SetSummary(
+        val metrics: List<WorkoutMetric>,
+        val peakPower: Float,
+        val averagePower: Float,
+        val repCount: Int
+    ) : WorkoutState()
     object Paused : WorkoutState()
     object Completed : WorkoutState()
     data class Error(val message: String) : WorkoutState()

--- a/app/src/main/java/com/example/vitruvianredux/presentation/components/SetSummaryCard.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/components/SetSummaryCard.kt
@@ -1,0 +1,265 @@
+package com.example.vitruvianredux.presentation.components
+
+import android.graphics.Color
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.graphics.toColorInt
+import com.example.vitruvianredux.domain.model.WeightUnit
+import com.example.vitruvianredux.domain.model.WorkoutMetric
+import com.example.vitruvianredux.ui.theme.Spacing
+import com.github.mikephil.charting.charts.LineChart
+import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.formatter.ValueFormatter
+
+/**
+ * Set Summary Card - Shows detailed metrics after completing a set
+ * Displays peak power, average power, rep count, and a force graph
+ */
+@Composable
+fun SetSummaryCard(
+    metrics: List<WorkoutMetric>,
+    peakPower: Float,
+    averagePower: Float,
+    repCount: Int,
+    weightUnit: WeightUnit,
+    formatWeight: (Float, WeightUnit) -> String,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.1f))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.medium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.medium)
+        ) {
+            // Header with checkmark
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Default.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(32.dp)
+                )
+                Spacer(modifier = Modifier.width(Spacing.small))
+                Text(
+                    "Set Complete!",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            // Stats Row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                // Peak Power
+                StatCard(
+                    label = "Peak",
+                    value = formatWeight(peakPower, weightUnit),
+                    modifier = Modifier.weight(1f)
+                )
+
+                Spacer(modifier = Modifier.width(Spacing.small))
+
+                // Average Power
+                StatCard(
+                    label = "Average",
+                    value = formatWeight(averagePower, weightUnit),
+                    modifier = Modifier.weight(1f)
+                )
+
+                Spacer(modifier = Modifier.width(Spacing.small))
+
+                // Rep Count
+                StatCard(
+                    label = "Reps",
+                    value = "$repCount",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            // Force Graph
+            if (metrics.isNotEmpty()) {
+                Text(
+                    "Force Over Time",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                ForceGraph(
+                    metrics = metrics,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                )
+            }
+
+            // Continue Button
+            Button(
+                onClick = onContinue,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text("Continue")
+                Spacer(modifier = Modifier.width(Spacing.small))
+                Icon(
+                    Icons.Default.KeyboardArrowRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Individual stat card for displaying a metric
+ */
+@Composable
+private fun StatCard(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.small),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
+    }
+}
+
+/**
+ * Force graph showing load over time during the set
+ */
+@Composable
+private fun ForceGraph(
+    metrics: List<WorkoutMetric>,
+    modifier: Modifier = Modifier
+) {
+    val isDark = androidx.compose.foundation.isSystemInDarkTheme()
+    val textColor = if (isDark) Color.WHITE else Color.BLACK
+    val gridColor = if (isDark) Color.DKGRAY else Color.LTGRAY
+
+    AndroidView(
+        factory = { context ->
+            LineChart(context).apply {
+                description.isEnabled = false
+                setTouchEnabled(true)
+                isDragEnabled = true
+                setScaleEnabled(true)
+                setPinchZoom(true)
+                setDrawGridBackground(false)
+                legend.isEnabled = false
+
+                // Configure X axis (time)
+                xAxis.apply {
+                    position = XAxis.XAxisPosition.BOTTOM
+                    setDrawGridLines(true)
+                    this.textColor = textColor
+                    this.gridColor = gridColor
+                    valueFormatter = object : ValueFormatter() {
+                        override fun getFormattedValue(value: Float): String {
+                            return "${value.toInt()}s"
+                        }
+                    }
+                }
+
+                // Configure Y axis (force/load)
+                axisLeft.apply {
+                    setDrawGridLines(true)
+                    this.textColor = textColor
+                    this.gridColor = gridColor
+                    axisMinimum = 0f
+                }
+
+                axisRight.isEnabled = false
+
+                setExtraOffsets(8f, 8f, 8f, 8f)
+            }
+        },
+        update = { chart ->
+            if (metrics.isEmpty()) {
+                chart.clear()
+                return@AndroidView
+            }
+
+            // Create entries for the chart (time in seconds vs total load)
+            val startTime = metrics.first().timestamp
+            val entries = metrics.map { metric ->
+                val elapsedSeconds = (metric.timestamp - startTime) / 1000f
+                Entry(elapsedSeconds, metric.totalLoad)
+            }
+
+            // Create dataset
+            val dataSet = LineDataSet(entries, "Force").apply {
+                color = "#9333EA".toColorInt() // Purple
+                setCircleColor("#9333EA".toColorInt())
+                lineWidth = 2f
+                circleRadius = 0f // No circles for cleaner look
+                setDrawCircleHole(false)
+                setDrawValues(false) // No values on points
+                mode = LineDataSet.Mode.CUBIC_BEZIER
+                setDrawFilled(true)
+                fillColor = "#9333EA".toColorInt()
+                fillAlpha = 50
+            }
+
+            chart.data = LineData(dataSet)
+            chart.invalidate()
+        },
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
@@ -143,6 +143,7 @@ fun ActiveWorkoutScreen(
             },
             onStopWorkout = { viewModel.stopWorkout() },
             onSkipRest = { viewModel.skipRest() },
+            onProceedFromSummary = { viewModel.proceedFromSummary() },
             onResetForNewWorkout = { viewModel.resetForNewWorkout() },
             onStartNextExercise = { viewModel.advanceToNextExercise() },
             onUpdateParameters = { viewModel.updateWorkoutParameters(it) },

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/WorkoutTab.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/WorkoutTab.kt
@@ -60,6 +60,7 @@ fun WorkoutTab(
     onStartWorkout: () -> Unit,
     onStopWorkout: () -> Unit,
     onSkipRest: () -> Unit,
+    onProceedFromSummary: () -> Unit = {},
     onResetForNewWorkout: () -> Unit,
     onStartNextExercise: () -> Unit = {},
     onUpdateParameters: (WorkoutParameters) -> Unit,
@@ -319,6 +320,17 @@ fun WorkoutTab(
                 if (!workoutParameters.isJustLift) {
                     CountdownCard(secondsRemaining = workoutState.secondsRemaining)
                 }
+            }
+            is WorkoutState.SetSummary -> {
+                com.example.vitruvianredux.presentation.components.SetSummaryCard(
+                    metrics = workoutState.metrics,
+                    peakPower = workoutState.peakPower,
+                    averagePower = workoutState.averagePower,
+                    repCount = workoutState.repCount,
+                    weightUnit = weightUnit,
+                    formatWeight = formatWeight,
+                    onContinue = onProceedFromSummary
+                )
             }
             is WorkoutState.Resting -> {
                 RestTimerCard(

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -852,6 +852,40 @@ class MainViewModel @Inject constructor(
             // Save progress
             saveWorkoutSession()
 
+            // Calculate metrics for summary
+            val peakPower = if (collectedMetrics.isNotEmpty()) {
+                collectedMetrics.maxOf { it.totalLoad }
+            } else {
+                0f
+            }
+
+            val averagePower = if (collectedMetrics.isNotEmpty()) {
+                collectedMetrics.map { it.totalLoad }.average().toFloat()
+            } else {
+                0f
+            }
+
+            val completedReps = _repCount.value.workingReps
+
+            // Transition to SetSummary state to show post-set metrics
+            _workoutState.value = WorkoutState.SetSummary(
+                metrics = collectedMetrics.toList(),
+                peakPower = peakPower,
+                averagePower = averagePower,
+                repCount = completedReps
+            )
+
+            Timber.d("Set summary: peak=$peakPower, avg=$averagePower, reps=$completedReps, metrics=${collectedMetrics.size}")
+            Timber.d("???????????????????????????????????????????????????")
+        }
+    }
+
+    /**
+     * Proceed from set summary to rest timer or completion
+     * Called when user clicks "Continue" button on set summary screen
+     */
+    fun proceedFromSummary() {
+        viewModelScope.launch {
             val routine = _loadedRoutine.value
             val isJustLift = workoutParameters.value.isJustLift
 


### PR DESCRIPTION
Implements Issue #6 - Enhanced post-set information display

Changes:
- Added WorkoutState.SetSummary state to show metrics after completing a set
- Modified handleSetCompletion() to transition to SetSummary before rest/completion
- Created SetSummaryCard composable with:
  * Peak power display
  * Average power display
  * Rep count display
  * Force-over-time graph using MPAndroidChart
- Added proceedFromSummary() function to transition from summary to rest/complete
- Integrated SetSummaryCard into WorkoutTab as an overlay
- Wired up callbacks in ActiveWorkoutScreen

The summary screen shows comprehensive workout data similar to the original Vitruvian app's exercise data page, helping users better understand their performance after each set.