### PR TITLE
Add confirmation dialog to End Workout button

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
@@ -141,7 +141,7 @@ fun ActiveWorkoutScreen(
                     onFailed = { /* Error shown via StateFlow */ }
                 )
             },
-            onStopWorkout = { viewModel.stopWorkout() },
+            onStopWorkout = { showExitConfirmation = true },
             onSkipRest = { viewModel.skipRest() },
             onResetForNewWorkout = { viewModel.resetForNewWorkout() },
             onStartNextExercise = { viewModel.advanceToNextExercise() },


### PR DESCRIPTION
The End Workout button now shows the same "Exit Workout?" confirmation dialog that the back button shows. This prevents accidentally ending a workout in progress.

Fixes: The onStopWorkout lambda now sets showExitConfirmation = true instead of directly calling viewModel.stopWorkout().