### PR TITLE
Fix missing rep beep by connecting HapticFeedbackEffect to ActiveWork…

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
@@ -57,6 +57,9 @@ fun ActiveWorkoutScreen(
         }
     }
 
+    // Haptic and audio feedback effect
+    HapticFeedbackEffect(hapticEvents = hapticEvents)
+
     // Watch for workout completion and navigate back
     // For Just Lift, navigate back when state becomes Idle (after auto-reset)
     LaunchedEffect(workoutState, workoutParameters) {


### PR DESCRIPTION
…outScreen

The haptic and audio feedback system was fully implemented but disconnected:
- MainViewModel.kt correctly emits HapticEvent.REP_COMPLETED
- HapticFeedbackEffect.kt has logic to play TONE_PROP_BEEP
- ActiveWorkoutScreen.kt collected hapticEvents but never called HapticFeedbackEffect

This change adds the missing HapticFeedbackEffect composable call in ActiveWorkoutScreen.kt to process the haptic events flow. Now users will hear the rep beep when completing each rep during a workout.

Fixes issue: Missing Rep Beep