### PR TITLE
Fix workout mode display bug - use exercise's workout type when loadi…

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -1396,7 +1396,7 @@ class MainViewModel @Inject constructor(
 
         updateWorkoutParameters(
             WorkoutParameters(
-                workoutType = _workoutParameters.value.workoutType, // Keep current workout type
+                workoutType = firstExercise.workoutType, // Use workout type from the exercise
                 reps = firstSetReps,
                 weightPerCableKg = firstExercise.weightPerCableKg,
                 progressionRegressionKg = firstExercise.progressionKg,


### PR DESCRIPTION
…ng routines

Fixed issue where the workout mode was showing incorrectly as "Old School" during exercises and in history, even when a different mode (e.g., "TUT") was selected.

The bug was in MainViewModel.loadRoutine() which was using the previous workoutParameters.workoutType instead of the exercise's configured workoutType.

This affected both single exercise workouts and routines, since both use loadRoutine() to initialize the workout parameters.

Changed:
- MainViewModel.kt line 1399: Use firstExercise.workoutType instead of _workoutParameters.value.workoutType when loading a routine

This ensures the selected workout mode is properly saved to history and displayed during the active workout.