### PR TITLE
Extend Just Lift auto-start hold timer from 1.2s to 3s

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -423,13 +423,17 @@ class MainViewModel @Inject constructor(
             return
         }
 
-        Timber.d("Auto-start timer STARTING! (1.2 seconds)")
+        Timber.d("Auto-start timer STARTING! (3 seconds)")
         autoStartJob = viewModelScope.launch {
-            // Official app: 1.2 second hold timer with visible countdown
-            _autoStartCountdown.value = 1  // Show "1" during hold
-            delay(1200)  // Official app: 1200ms hold
+            // User preference: 3 second hold timer with visible countdown
+            _autoStartCountdown.value = 3
+            delay(1000)
+            _autoStartCountdown.value = 2
+            delay(1000)
+            _autoStartCountdown.value = 1
+            delay(1000)
             _autoStartCountdown.value = null
-            Timber.d("Auto-start hold complete (1.2s)! Starting workout...")
+            Timber.d("Auto-start hold complete (3s)! Starting workout...")
             // Just Lift mode: Pass isJustLiftMode=true to ensure flag is preserved
             startWorkout(isJustLiftMode = true)
         }


### PR DESCRIPTION
- Updated startAutoStartTimer() to use 3-second countdown (3, 2, 1)
- Changed delay from 1200ms to 3000ms (3 x 1000ms)
- Enhanced user feedback with visible countdown for each second
- Updated log messages to reflect new 3-second timing

This addresses user request for a longer hold timer in Just Lift mode, providing better control and preventing accidental workout starts.