### PR TITLE
Add cancel button to connection overlay (Issue #5)

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/components/ConnectingOverlay.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/components/ConnectingOverlay.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,10 +16,12 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
- * Full-screen overlay showing "Connecting..." with animation
+ * Full-screen overlay showing "Connecting..." with animation and cancel option
  */
 @Composable
-fun ConnectingOverlay() {
+fun ConnectingOverlay(
+    onCancel: () -> Unit = {}
+) {
     Dialog(
         onDismissRequest = { /* Non-dismissible */ },
         properties = DialogProperties(
@@ -55,6 +58,12 @@ fun ConnectingOverlay() {
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    TextButton(
+                        onClick = onCancel,
+                        modifier = Modifier.padding(top = 8.dp)
+                    ) {
+                        Text("Cancel")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavGraph.kt
@@ -191,7 +191,8 @@ fun NavGraph(
                 onNavigateToConnectionLogs = { navController.navigate(NavigationRoutes.ConnectionLogs.route) },
                 isAutoConnecting = isAutoConnecting,
                 connectionError = connectionError,
-                onClearConnectionError = { viewModel.clearConnectionError() }
+                onClearConnectionError = { viewModel.clearConnectionError() },
+                onCancelAutoConnecting = { viewModel.cancelAutoConnecting() }
             )
         }
 

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
@@ -183,7 +183,9 @@ fun ActiveWorkoutScreen(
 
     // Auto-connect UI overlays (same as other screens)
     if (isAutoConnecting) {
-        com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+        com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+            onCancel = { viewModel.cancelAutoConnecting() }
+        )
     }
 
     connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/AnalyticsScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/AnalyticsScreen.kt
@@ -169,7 +169,9 @@ fun AnalyticsScreen(
 
         // Auto-connect UI overlays (same as other screens)
         if (isAutoConnecting) {
-            com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+            com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+                onCancel = { viewModel.cancelAutoConnecting() }
+            )
         }
 
         connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ConnectionLogsScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ConnectionLogsScreen.kt
@@ -248,7 +248,9 @@ fun ConnectionLogsScreen(
 
     // Auto-connect UI overlays (same as other screens)
     if (isAutoConnecting) {
-        com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+        com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+            onCancel = { mainViewModel.cancelAutoConnecting() }
+        )
     }
 
     connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/DailyRoutinesScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/DailyRoutinesScreen.kt
@@ -110,7 +110,9 @@ fun DailyRoutinesScreen(
 
         // Auto-connect UI overlays
         if (isAutoConnecting) {
-            com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+            com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+                onCancel = { viewModel.cancelAutoConnecting() }
+            )
         }
 
         connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
@@ -357,6 +357,7 @@ fun SettingsTab(
     isAutoConnecting: Boolean = false,
     connectionError: String? = null,
     onClearConnectionError: () -> Unit = {},
+    onCancelAutoConnecting: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var showDeleteAllDialog by remember { mutableStateOf(false) }
@@ -798,7 +799,9 @@ fun SettingsTab(
 
     // Auto-connect UI overlays (same as other screens)
     if (isAutoConnecting) {
-        com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+        com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+            onCancel = onCancelAutoConnecting
+        )
     }
 
     connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/HomeScreen.kt
@@ -170,7 +170,9 @@ fun HomeScreen(
 
         // Auto-connect UI overlays (same as exercise start screens)
         if (isAutoConnecting) {
-            com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+            com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+                onCancel = { viewModel.cancelAutoConnecting() }
+            )
         }
 
         connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/JustLiftScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/JustLiftScreen.kt
@@ -443,7 +443,9 @@ fun JustLiftScreen(
 
             // Auto-connect UI overlays
             if (isAutoConnecting) {
-                com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+                com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+                    onCancel = { viewModel.cancelAutoConnecting() }
+                )
             }
 
             connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ProgramBuilderScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ProgramBuilderScreen.kt
@@ -309,7 +309,9 @@ fun ProgramBuilderScreen(
 
     // Auto-connect UI overlays (same as other screens)
     if (isAutoConnecting) {
-        com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+        com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+            onCancel = { viewModel.cancelAutoConnecting() }
+        )
     }
 
     connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/SingleExerciseScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/SingleExerciseScreen.kt
@@ -166,7 +166,9 @@ fun SingleExerciseScreen(
         }
 
         if (isAutoConnecting) {
-            ConnectingOverlay()
+            ConnectingOverlay(
+                onCancel = { viewModel.cancelAutoConnecting() }
+            )
         }
 
         connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/WeeklyProgramsScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/WeeklyProgramsScreen.kt
@@ -228,7 +228,9 @@ fun WeeklyProgramsScreen(
 
             // Auto-connect UI overlays
             if (isAutoConnecting) {
-                com.example.vitruvianredux.presentation.components.ConnectingOverlay()
+                com.example.vitruvianredux.presentation.components.ConnectingOverlay(
+                    onCancel = { viewModel.cancelAutoConnecting() }
+                )
             }
 
             connectionError?.let { error ->

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -637,6 +637,25 @@ class MainViewModel @Inject constructor(
         _connectionError.value = null
     }
 
+    /**
+     * Cancel the auto-connection process.
+     * This stops scanning, clears pending callbacks, and hides the connecting overlay.
+     */
+    fun cancelAutoConnecting() {
+        viewModelScope.launch {
+            Timber.d("User cancelled auto-connection")
+            _isAutoConnecting.value = false
+            _pendingConnectionCallback = null
+            stopScanning()
+
+            // If we're in the middle of connecting, disconnect
+            val currentState = connectionState.value
+            if (currentState is ConnectionState.Connecting) {
+                bleRepository.disconnect()
+            }
+        }
+    }
+
     fun dismissConnectionLostAlert() {
         _connectionLostDuringWorkout.value = false
     }


### PR DESCRIPTION
Implemented a cancel option for the "Connecting..." overlay that appears during auto-connect to the trainer, addressing user feedback about being unable to abort accidental connection attempts.

Changes:
- Added cancelAutoConnecting() function to MainViewModel to stop scanning, clear pending callbacks, and dismiss the overlay
- Modified ConnectingOverlay component to include a Cancel button
- Updated all screens using ConnectingOverlay to wire the cancel callback
- Added onCancelAutoConnecting parameter to SettingsTab and its usage

The cancel button allows users to abort the connection process at any time instead of waiting for the timeout.