### PR TITLE
Test and debug application flows

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ActiveWorkoutScreen.kt
@@ -74,6 +74,11 @@ fun ActiveWorkoutScreen(
                 // Just Lift completed and reset to Idle - navigate back to Just Lift screen
                 navController.navigateUp()
             }
+            workoutState is WorkoutState.Error -> {
+                // Show error for 3 seconds then navigate back
+                delay(3000)
+                navController.navigateUp()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/JustLiftScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/JustLiftScreen.kt
@@ -78,9 +78,10 @@ fun JustLiftScreen(
         }
     }
 
-    // Reset workout state if entering Just Lift with a completed workout
+    // Reset workout state if entering Just Lift with any non-Idle state
+    // This ensures the AutoStartStopCard is always visible
     LaunchedEffect(workoutState) {
-        if (workoutState is WorkoutState.Completed) {
+        if (workoutState !is WorkoutState.Idle && workoutState !is WorkoutState.Active) {
             viewModel.prepareForJustLift()
         }
     }

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/WorkoutTab.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/WorkoutTab.kt
@@ -151,6 +151,50 @@ fun WorkoutTab(
                         }
                     }
                 }
+                is WorkoutState.Error -> {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                        shape = RoundedCornerShape(16.dp),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.5f))
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(Spacing.medium),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(Spacing.small)
+                        ) {
+                            Icon(
+                                Icons.Default.Warning,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(48.dp)
+                            )
+                            Text(
+                                "Workout Failed to Start",
+                                style = MaterialTheme.typography.titleLarge,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Spacer(modifier = Modifier.height(Spacing.small))
+                            Text(
+                                workoutState.message,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                textAlign = TextAlign.Center
+                            )
+                            Spacer(modifier = Modifier.height(Spacing.small))
+                            Text(
+                                "Returning to previous screen...",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f),
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
+                }
                 is WorkoutState.Completed -> {
                     Card(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -707,13 +707,14 @@ class MainViewModel @Inject constructor(
 
     /**
      * Prepare the ViewModel for Just Lift mode.
-     * If a previous workout was completed, reset the state to Idle so Just Lift can work.
-     * This is called when entering the JustLiftScreen with a completed workout.
+     * If a previous workout was in any non-Idle state, reset to Idle so Just Lift can work.
+     * This is called when entering the JustLiftScreen.
      */
     fun prepareForJustLift() {
         viewModelScope.launch {
-            if (_workoutState.value is WorkoutState.Completed) {
-                Timber.d("Preparing for Just Lift: Resetting completed workout state")
+            val currentState = _workoutState.value
+            if (currentState !is WorkoutState.Idle) {
+                Timber.d("Preparing for Just Lift: Resetting from ${currentState::class.simpleName} to Idle")
                 resetForNewWorkout()
                 _workoutState.value = WorkoutState.Idle
                 enableHandleDetection()
@@ -722,6 +723,9 @@ class MainViewModel @Inject constructor(
                     useAutoStart = true
                 )
                 Timber.d("Just Lift ready: State=Idle, AutoStart=enabled")
+            } else {
+                Timber.d("Just Lift already in Idle state, ensuring auto-start is enabled")
+                enableHandleDetection()
             }
         }
     }


### PR DESCRIPTION
Addresses issue #91 where workout flows failed on some devices.

**Issue 1: Just Lift AutoStart Ready card not appearing**
- Root cause: prepareForJustLift() only reset state from Completed
- Other states (Error, Countdown, Paused) left AutoStartStopCard hidden
- Fixed: Reset to Idle for ALL non-Idle states when entering Just Lift
- Files: MainViewModel.kt, JustLiftScreen.kt

**Issue 2: Single exercise launch fails with "window flash"**
- Root cause: No UI handling for WorkoutState.Error
- BLE command failures after countdown showed blank screen
- Fixed: Added error card in WorkoutTab with auto-navigation after 3s
- Files: WorkoutTab.kt, ActiveWorkoutScreen.kt

Changes:
- MainViewModel.prepareForJustLift(): Check for non-Idle instead of just Completed
- JustLiftScreen: Trigger prepareForJustLift for any non-Idle/Active state
- WorkoutTab: Add error state UI card with warning icon and message
- ActiveWorkoutScreen: Add error state navigation after 3s delay