### PR TITLE
Resolve GitHub Issue #66 in VitruvianProjectPhoenix

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/CountdownCard.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/CountdownCard.kt
@@ -71,7 +71,7 @@ fun CountdownCard(secondsRemaining: Int) {
                     text = "$secondsRemaining",
                     style = MaterialTheme.typography.displayLarge.copy(fontSize = 96.sp),
                     fontWeight = FontWeight.ExtraBold,
-                    color = MaterialTheme.colorScheme.onSurface
+                    color = MaterialTheme.colorScheme.primary
                 )
             }
 

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/RestTimerCard.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/RestTimerCard.kt
@@ -118,10 +118,10 @@ fun RestTimerCard(
                 Surface(
                     modifier = Modifier.size(220.dp),
                     shape = RoundedCornerShape(200.dp),
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 8.dp,
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    tonalElevation = 0.dp,
                     shadowElevation = 8.dp,
-                    border = BorderStroke(1.dp, Color(0xFFF5F3FF))
+                    border = BorderStroke(2.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))
                 ) {
                     Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
                         // Time remaining
@@ -129,7 +129,7 @@ fun RestTimerCard(
                             text = formatRestTime(restSecondsRemaining),
                             style = MaterialTheme.typography.displayLarge,
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
+                            color = MaterialTheme.colorScheme.primary
                         )
                     }
                 }


### PR DESCRIPTION
The countdown timer numbers were not visible between sets in single exercise mode. While PR #71 attempted to fix this by changing text color from primary to onSurface, users reported the timer was still invisible.

Root cause: The tonal elevation on the circular timer surface was interfering with color rendering, and the onSurface color wasn't providing enough visual contrast in all lighting conditions.

Changes:
- RestTimerCard: Changed timer text color back to primary (which is more vibrant and visible) and updated surface to use surfaceContainerHighest for better differentiation
- Removed tonal elevation (set to 0.dp) to prevent color interference
- Increased border width from 1.dp to 2.dp and made it semi-transparent primary color for better visual definition
- CountdownCard: Changed text color back to primary for consistency and better visibility

The primary color provides better contrast and visibility in both light and dark modes:
- Light mode: TertiaryPurple (#E0BBF7) is more visible than the dark gray onSurface color on white backgrounds
- Dark mode: PrimaryPurple (#BB86FC) stands out well against dark surfaces

Fixes #66