### PR TITLE
Resolve GitHub Issue #98 in VitruvianProjectPhoenix

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/domain/usecase/RepCounterFromMachine.kt
+++ b/app/src/main/java/com/example/vitruvianredux/domain/usecase/RepCounterFromMachine.kt
@@ -79,6 +79,25 @@ class RepCounterFromMachine {
         minRepPosBRange = null
     }
 
+    /**
+     * Sets the initial baseline position when the workout starts (after countdown completes).
+     * This calibrates the position bars to the starting rope position, so bars show 0% at
+     * the starting position rather than showing raw machine values.
+     *
+     * The baseline will be refined as reps are performed through the sliding window calibration.
+     */
+    fun setInitialBaseline(posA: Int, posB: Int) {
+        // Only set initial baseline if positions are valid and not already calibrated
+        if (posA > 0 && minRepPosA == null) {
+            minRepPosA = posA
+            minRepPosARange = Pair(posA, posA)
+        }
+        if (posB > 0 && minRepPosB == null) {
+            minRepPosB = posB
+            minRepPosBRange = Pair(posB, posB)
+        }
+    }
+
     fun process(topCounter: Int, completeCounter: Int, posA: Int = 0, posB: Int = 0) {
 
         if (lastTopCounter != null) {

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -794,6 +794,14 @@ class MainViewModel @Inject constructor(
             // Set state to Active immediately before sending BLE command for instant UI response
             _workoutState.value = WorkoutState.Active
 
+            // Set initial baseline position for position bars calibration
+            // This ensures bars start at 0% relative to the starting rope position
+            _currentMetric.value?.let { metric ->
+                repCounter.setInitialBaseline(metric.positionA, metric.positionB)
+                _repRanges.value = repCounter.getRepRanges()
+                Timber.d("?? POSITION BASELINE: Set initial baseline to posA=${metric.positionA}, posB=${metric.positionB}")
+            }
+
             val result = bleRepository.startWorkout(params)
 
             val commandLatency = System.currentTimeMillis() - startTime


### PR DESCRIPTION
Fixes #98

Problem:
- Position bars were showing raw machine values (e.g., 70% at shoulder height)
- Calibration only occurred after performing reps
- This made bars appear already filled at workout start

Solution:
- Capture rope position when countdown completes (workout becomes active)
- Set this position as initial baseline (minRepPos) for position bars
- Bars now show 0% at starting position, 100% at full extension
- Sliding window calibration still refines the range as reps are performed

This matches the expected behavior where "the bottom position of the bars is set to the position the ropes are in when the start timer is completed."

Changes:
- RepCounterFromMachine: Added setInitialBaseline() method
- MainViewModel: Call setInitialBaseline() when workout becomes active