### PR TITLE
Resolve GitHub Issue #103 in VitruvianProjectPhoenix

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -737,12 +737,18 @@ class MainViewModel @Inject constructor(
                 enableHandleDetection()
                 _workoutParameters.value = _workoutParameters.value.copy(
                     isJustLift = true,
-                    useAutoStart = true
+                    useAutoStart = true,
+                    selectedExerciseId = null
                 )
                 Timber.d("Just Lift ready: State=Idle, AutoStart=enabled")
             } else {
                 Timber.d("Just Lift already in Idle state, ensuring auto-start is enabled")
                 enableHandleDetection()
+                _workoutParameters.value = _workoutParameters.value.copy(
+                    isJustLift = true,
+                    useAutoStart = true,
+                    selectedExerciseId = null
+                )
             }
         }
     }


### PR DESCRIPTION
When entering Just Lift mode after completing a Single Exercise workout, the previous exercise's name and video were incorrectly displayed during the Just Lift session.

Root cause: The prepareForJustLift() function was setting isJustLift=true but not clearing the selectedExerciseId from workoutParameters. This caused the CurrentExerciseCard component to load and display the previous exercise data based on the stale selectedExerciseId.

Changes:
- Clear selectedExerciseId in both branches of prepareForJustLift()
- Ensures workout parameters are properly updated even when already in Idle state

Fixes #103