### PR TITLE
Fix machine connection and exercise startup issues

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
@@ -242,6 +242,8 @@ class VitruvianBleManager(
             monitorCharacteristic = null
             propertyCharacteristic = null
             repNotifyCharacteristic = null
+            workoutCmdCharacteristics.clear()
+            notifyCharacteristics.clear()
 
             // CRITICAL FIX: Update connection state to reflect that characteristics are invalid
             // This prevents the app from trying to send commands with null characteristics


### PR DESCRIPTION
Issue: Users reported machines not starting exercises or appearing disconnected even when the app showed as connected. Investigation revealed that onServicesInvalidated() was being called (typically ~5 seconds after connection), which nulled all BLE characteristics but didn't update the connection state. This caused commands to fail silently with "NUS RX characteristic not available".

Root Cause:
- onServicesInvalidated() was nulling characteristics but not updating connection state
- Missing onDeviceDisconnected() callback implementation
- No onDeviceNotSupported() handling

Changes:
1. onServicesInvalidated() now:
   - Updates connection state to Disconnected
   - Stops all polling jobs
   - Provides clear logging about state change

2. Added onDeviceDisconnected() callback:
   - Properly handles disconnection events
   - Updates connection state
   - Stops polling and logs disconnection

3. Added onDeviceNotSupported() callback:
   - Handles devices without required BLE services
   - Sets specific error state with descriptive message

Impact:
- App now properly reflects disconnected state in UI
- Users will see clear indication when connection is lost
- Prevents silent command failures with null characteristics
- Fixes issue #91

Related: #91