### PR TITLE
Redesign AnalyticsScreen with Dashboard, Trends, and routine grouping…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,11 @@ dependencies {
     // Chart Library - MPAndroidChart
     implementation(libs.mpandroidchart)
 
+    // Vico Charts - Modern Compose charting library
+    implementation(libs.vico.compose)
+    implementation(libs.vico.compose.m3)
+    implementation(libs.vico.core)
+
     // Logging - Timber
     implementation(libs.timber)
 

--- a/app/src/main/java/com/example/vitruvianredux/data/local/WorkoutDatabase.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/local/WorkoutDatabase.kt
@@ -8,6 +8,7 @@ import androidx.room.TypeConverters
  * Room database for workout history
  *
  * Version history:
+ * - v16: Added routineSessionId and routineName to workout_sessions for grouping routine sets in history
  * - v15: Added exerciseId to workout_sessions for PR tracking
  * - v14: Added ConnectionLogEntity for Bluetooth connection debugging
  * - v13: Added eccentricLoad and echoLevel to workout_sessions for Echo mode persistence
@@ -33,7 +34,7 @@ import androidx.room.TypeConverters
         ProgramDayEntity::class,
         ConnectionLogEntity::class
     ],
-    version = 15,
+    version = 16,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/vitruvianredux/data/local/WorkoutEntities.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/local/WorkoutEntities.kt
@@ -29,7 +29,10 @@ data class WorkoutSessionEntity(
     val eccentricLoad: Int = 100,  // Percentage (0, 50, 75, 100, 125, 150)
     val echoLevel: Int = 1,  // 0=Hard, 1=Harder, 2=Hardest, 3=Epic (stores levelValue)
     // Exercise tracking (added in v15)
-    val exerciseId: String? = null  // Exercise library ID for PR tracking
+    val exerciseId: String? = null,  // Exercise library ID for PR tracking
+    // Routine tracking (for grouping sets from the same routine)
+    val routineSessionId: String? = null,  // Unique ID for this routine session
+    val routineName: String? = null  // Name of the routine being performed
 )
 
 /**

--- a/app/src/main/java/com/example/vitruvianredux/domain/model/Models.kt
+++ b/app/src/main/java/com/example/vitruvianredux/domain/model/Models.kt
@@ -261,7 +261,10 @@ data class WorkoutSession(
     val eccentricLoad: Int = 100,  // Percentage (0, 50, 75, 100, 125, 150)
     val echoLevel: Int = 2,  // 1=Hard, 2=Harder, 3=Hardest, 4=Epic
     // Exercise tracking
-    val exerciseId: String? = null  // Exercise library ID for PR tracking
+    val exerciseId: String? = null,  // Exercise library ID for PR tracking
+    // Routine tracking (for grouping sets from the same routine)
+    val routineSessionId: String? = null,  // Unique ID for this routine session
+    val routineName: String? = null  // Name of the routine being performed
 )
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ mockitoCore = "5.11.0"
 mockitoInline = "5.2.0"
 robolectric = "4.11.1"
 ksp = "2.0.21-1.0.26"
+vico = "2.0.0-alpha.28"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -69,6 +70,11 @@ nordic-ble-ktx = { group = "no.nordicsemi.android", name = "ble-ktx", version.re
 
 # MPAndroidChart
 mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpAndroidChart" }
+
+# Vico Charts
+vico-compose = { group = "com.patrykandpatrick.vico", name = "compose", version.ref = "vico" }
+vico-compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", version.ref = "vico" }
+vico-core = { group = "com.patrykandpatrick.vico", name = "core", version.ref = "vico" }
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }


### PR DESCRIPTION
… in History

This commit implements a comprehensive redesign of the AnalyticsScreen to make it "truly useful and gorgeous" with the following major enhancements:

## 1. New Tab Structure (Dashboard, Trends, History)
- Changed tabs from "History, Personal Bests, Trends" to "Dashboard, Trends, History"
- Dashboard is now the default landing tab for quick insights
- Personal Bests content integrated into Dashboard and Trends tabs

## 2. Dashboard Tab (NEW)
- 2x2 grid of key statistics:
  * Total Workouts (from completedWorkouts)
  * Workout Streak (from workoutStreak)
  * Total Volume (calculated from all sessions)
  * Total PRs (from allPersonalRecords count)
- Placeholder for calendar heatmap (for future enhancement)
- Muscle group distribution visualization using existing MPAndroidChart

## 3. Enhanced Trends Tab
- Now includes ranked Personal Records list showing best lift per exercise
- Maintains existing PR progression charts
- Clear separation between "Personal Bests" and "Progression Details" sections

## 4. Routine Grouping in History (CORE FEATURE)
- Workout sessions from the same routine are now grouped into a single expandable card
- Data Model Changes:
  * Added `routineSessionId` and `routineName` to WorkoutSession entity
  * Incremented database version from 15 to 16
- ViewModel Logic:
  * Track routine sessions with unique ID generated in loadRoutine()
  * Clear routine tracking when routine completes or is cleared
  * Save routine info with each workout session
- UI Implementation:
  * Created HistoryItem sealed class hierarchy:
    - SingleSessionHistoryItem (for standalone workouts)
    - GroupedRoutineHistoryItem (for grouped routine sessions)
  * Created groupedWorkoutHistory StateFlow that groups sessions by routineSessionId
  * GroupedRoutineCard shows:
    - Routine name and timestamp
    - Total duration, total reps, exercise count, set count
    - Expandable to show individual WorkoutSessionCard for each set
    - Ability to delete all sets in the routine at once
  * Maintains existing WorkoutHistoryCard for single sessions

## 5. Added Vico Charting Library
- Added Vico dependencies (compose, compose-m3, core) for future chart migration
- Vico is a modern, native Jetpack Compose charting library with Material 3 support
- Chart rewrites deferred to future work

## Technical Details
- All nullable fields use default null values for backward compatibility
- Room handles database migration automatically for nullable additions
- Existing workout history preserved and displayed correctly
- Routine tracking fields only populated when workout is part of a routine

## Files Modified
- app/build.gradle.kts: Added Vico dependencies
- gradle/libs.versions.toml: Added Vico version and library definitions
- WorkoutDatabase.kt: Incremented version to 16
- WorkoutEntities.kt: Added routineSessionId and routineName to WorkoutSessionEntity
- Models.kt: Added routineSessionId and routineName to WorkoutSession domain model
- MainViewModel.kt: Added routine tracking logic and groupedWorkoutHistory StateFlow
- AnalyticsScreen.kt: Redesigned tabs, added DashboardTab, updated TrendsTab
- HistoryAndSettingsTabs.kt: Updated HistoryTab, added GroupedRoutineCard

Refs: Sequential task planning for Analytics redesign