### PR TITLE
fix: Implement correct bodyweight exercise support using existing dur…

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -113,6 +113,16 @@ class ExerciseConfigViewModel @Inject constructor() : ViewModel() {
         // Use PR weight as default if available, otherwise use 15kg
         val defaultWeightKg = prWeightKg ?: 15f
 
+        // Determine default duration and log if defaulting for bodyweight exercises
+        val defaultDuration = if (exercise.duration != null) {
+            exercise.duration
+        } else {
+            if (_exerciseType.value == ExerciseType.BODYWEIGHT) {
+                Timber.w("Bodyweight exercise '${exercise.exercise.name}' missing duration - defaulting to 30s")
+            }
+            30
+        }
+
         val initialSets = exercise.setReps.mapIndexed { index, reps ->
             val perSetWeightKg = exercise.setWeightsPerCableKg.getOrNull(index) ?: exercise.weightPerCableKg
             val perSetRest = exercise.setRestSeconds.getOrNull(index) ?: 60
@@ -121,7 +131,7 @@ class ExerciseConfigViewModel @Inject constructor() : ViewModel() {
                 setNumber = index + 1,
                 reps = reps, // Preserve null for AMRAP sets
                 weightPerCable = kgToDisplay(perSetWeightKg, weightUnit),
-                duration = exercise.duration ?: 30,
+                duration = defaultDuration,
                 restSeconds = perSetRest
             )
         }.ifEmpty {


### PR DESCRIPTION
…ation infrastructure

This implementation fixes issue #125 by properly supporting bodyweight exercises without requiring cable weight selection or warmup, while maintaining compatibility with multi-exercise routines.

Changes:
- ExerciseConfigViewModel: Force SetMode.DURATION for bodyweight exercises (empty equipment)
- ExerciseConfigViewModel: Prevent users from switching bodyweight exercises to REPS mode
- MainViewModel: Detect bodyweight exercises with duration and skip BLE cable commands
- MainViewModel: Skip warmup reps for bodyweight exercises
- MainViewModel: Use timer-based completion for bodyweight exercises instead of cable rep counting

Key architectural decisions:
- Uses existing RoutineExercise.duration field (not new WorkoutParameters fields)
- Uses existing SetMode.DURATION infrastructure (not parallel system)
- Bodyweight detection: exercise.equipment.isEmpty() && exercise.duration != null
- Cable exercises can still use both REPS and DURATION modes
- Mixed routines with both bodyweight and cable exercises are fully supported

Fixes #125