### PR TITLE
fix: Add BLE queue drain delay to prevent connection drops on Android…

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/data/repository/BleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/repository/BleRepositoryImpl.kt
@@ -540,6 +540,14 @@ class BleRepositoryImpl @Inject constructor(
             val afterPollingStop = System.currentTimeMillis()
             Timber.d("STOP_DEBUG: [$afterPollingStop] AFTER stopping polling jobs (took ${afterPollingStop - beforePollingStop}ms)")
 
+            // FIX FOR ISSUE #124: Add delay to allow BLE queue to drain pending operations
+            // This prevents race condition where INIT command is sent while rep notifications
+            // or monitor reads are still being processed, especially critical on Android 16
+            // which has stricter BLE timing enforcement
+            Timber.d("STOP_DEBUG: Waiting 250ms for BLE queue to drain...")
+            delay(250)
+            Timber.d("STOP_DEBUG: BLE queue drain delay complete")
+
             // Send INIT command to stop workout and release resistance
             // NOTE: Web app uses buildInitCommand() to stop, not a separate stop command
             // The device interprets 0x0A contextually based on current state

--- a/app/src/main/java/com/example/vitruvianredux/data/repository/BleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/repository/BleRepositoryImpl.kt
@@ -545,7 +545,7 @@ class BleRepositoryImpl @Inject constructor(
             // or monitor reads are still being processed, especially critical on Android 16
             // which has stricter BLE timing enforcement
             Timber.d("STOP_DEBUG: Waiting 250ms for BLE queue to drain...")
-            delay(250)
+            delay(BleConstants.BLE_QUEUE_DRAIN_DELAY_MS)
             Timber.d("STOP_DEBUG: BLE queue drain delay complete")
 
             // Send INIT command to stop workout and release resistance


### PR DESCRIPTION
… 16 (#124)

Adds a 250ms delay between stopPolling() and sending the INIT command in stopWorkout() to allow the BLE operation queue to drain pending operations.

Root Cause:
- When exercise timer reaches zero and warmup completes (3 reps), handleSetCompletion() calls stopWorkout()
- stopWorkout() immediately cancels polling jobs and sends INIT command
- At this moment, BLE queue may still have pending rep notifications, monitor reads, and characteristic updates
- INIT command is enqueued while BLE stack is still processing these operations
- Android 16's stricter BLE timing enforcement causes connection to drop

The Fix:
- Added 250ms delay after stopPolling() before sending INIT command
- This allows pending BLE operations to complete before INIT is sent
- Prevents race condition that causes connection drop
- Especially important for Android 16 (targetSdk=36) with stricter timing

Affected Modes:
- Just Lift mode
- Single Exercise mode
- Any mode where auto-stop triggers at warmup completion

References:
- Issue #124: Connection drops when timer reaches zero and 3 warmup reps complete
- BleRepositoryImpl.kt:543-549 - Added delay with documentation
- Different from "5 second disconnect" - this is a specific timer completion race condition