### PR TITLE
Phase 1: Fix deprecated Divider → HorizontalDivider

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/components/ConnectionErrorDialog.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/components/ConnectionErrorDialog.kt
@@ -33,7 +33,7 @@ fun ConnectionErrorDialog(
                     style = MaterialTheme.typography.bodyMedium
                 )
 
-                Divider(modifier = Modifier.padding(vertical = 4.dp))
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
                 Text(
                     text = "Troubleshooting tips:",


### PR DESCRIPTION
## Phase 1: Quick Fixes - Deprecated Divider

This PR addresses the deprecated `Divider` component warning by replacing it with `HorizontalDivider` in ConnectionErrorDialog.kt.

### Changes
- ✅ Replaced `Divider` with `HorizontalDivider` on line 36
- Fixes compilation warning about deprecated Material 3 component

### Related
Part of the Phase 1-3 stability and performance improvements outlined in the project roadmap.

**Note:** Deprecated icon fixes (List, ArrowBack, BluetoothSearching) were already completed in previous commits.