### PR TITLE
Export debug logs from Android device

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavGraph.kt
@@ -192,6 +192,7 @@ fun NavGraph(
                 onColorSchemeChange = { viewModel.setColorScheme(it) },
                 onDeleteAllWorkouts = { viewModel.deleteAllWorkouts() },
                 onNavigateToConnectionLogs = { navController.navigate(NavigationRoutes.ConnectionLogs.route) },
+                onNavigateToProtocolTester = { navController.navigate(NavigationRoutes.ProtocolTester.route) },
                 isAutoConnecting = isAutoConnecting,
                 connectionError = connectionError,
                 onClearConnectionError = { viewModel.clearConnectionError() },
@@ -205,6 +206,39 @@ fun NavGraph(
             ConnectionLogsScreen(
                 onNavigateBack = { navController.popBackStack() },
                 mainViewModel = viewModel
+            )
+        }
+
+        // Protocol Tester screen - diagnostic tool for BLE protocol testing
+        composable(
+            route = NavigationRoutes.ProtocolTester.route,
+            enterTransition = {
+                slideIntoContainer(
+                    towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                    animationSpec = tween(300)
+                )
+            },
+            exitTransition = {
+                slideOutOfContainer(
+                    towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                    animationSpec = tween(300)
+                )
+            },
+            popEnterTransition = {
+                slideIntoContainer(
+                    towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                    animationSpec = tween(300)
+                )
+            },
+            popExitTransition = {
+                slideOutOfContainer(
+                    towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                    animationSpec = tween(300)
+                )
+            }
+        ) {
+            ProtocolTesterScreen(
+                onNavigateBack = { navController.popBackStack() }
             )
         }
     }

--- a/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/navigation/NavigationRoutes.kt
@@ -17,6 +17,7 @@ sealed class NavigationRoutes(val route: String) {
     object Analytics : NavigationRoutes("analytics")
     object Settings : NavigationRoutes("settings")
     object ConnectionLogs : NavigationRoutes("connection_logs")
+    object ProtocolTester : NavigationRoutes("protocol_tester")
 }
 
 /**

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/HistoryAndSettingsTabs.kt
@@ -780,6 +780,7 @@ fun SettingsTab(
     onColorSchemeChange: (Int) -> Unit,
     onDeleteAllWorkouts: () -> Unit,
     onNavigateToConnectionLogs: () -> Unit = {},
+    onNavigateToProtocolTester: () -> Unit = {},
     isAutoConnecting: Boolean = false,
     connectionError: String? = null,
     onClearConnectionError: () -> Unit = {},
@@ -1228,6 +1229,35 @@ fun SettingsTab(
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     "View Bluetooth connection debug logs to diagnose connectivity issues",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(Spacing.medium))
+
+                OutlinedButton(
+                    onClick = onNavigateToProtocolTester,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(20.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Science,
+                        contentDescription = "Protocol Tester",
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.small))
+                    Text(
+                        "Protocol Tester",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    "Test different BLE connection protocols to find what works best for your device",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/ProtocolTesterScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/ProtocolTesterScreen.kt
@@ -1,0 +1,650 @@
+package com.example.vitruvianredux.presentation.screen
+
+import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.vitruvianredux.presentation.viewmodel.ProtocolTesterViewModel
+import com.example.vitruvianredux.presentation.viewmodel.ProtocolTesterViewModel.TestMode
+import com.example.vitruvianredux.presentation.viewmodel.ProtocolTesterViewModel.TestState
+import com.example.vitruvianredux.ui.theme.Spacing
+import com.example.vitruvianredux.util.ProtocolTester.TestResult
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProtocolTesterScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ProtocolTesterViewModel = hiltViewModel()
+) {
+    val testState by viewModel.testState.collectAsState()
+    val results by viewModel.results.collectAsState()
+    val currentDevice by viewModel.currentDeviceName.collectAsState()
+    val testMode by viewModel.testMode.collectAsState()
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            "Protocol Tester",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                        currentDevice?.let {
+                            Text(
+                                "Device: $it",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (testState is TestState.Completed) {
+                        IconButton(
+                            onClick = {
+                                val report = viewModel.generateReport()
+                                val sendIntent = Intent().apply {
+                                    action = Intent.ACTION_SEND
+                                    putExtra(Intent.EXTRA_TEXT, report)
+                                    type = "text/plain"
+                                }
+                                context.startActivity(Intent.createChooser(sendIntent, "Share Protocol Test Report"))
+                            }
+                        ) {
+                            Icon(Icons.Default.Share, contentDescription = "Share Report")
+                        }
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(Spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(Spacing.medium)
+        ) {
+            // Info card
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(8.dp, RoundedCornerShape(20.dp)),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+                shape = RoundedCornerShape(20.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                border = BorderStroke(2.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(Spacing.medium)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .shadow(8.dp, RoundedCornerShape(20.dp))
+                                .background(
+                                    Brush.linearGradient(
+                                        colors = listOf(Color(0xFF8B5CF6), Color(0xFF9333EA))
+                                    ),
+                                    RoundedCornerShape(20.dp)
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                Icons.Default.Science,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onPrimary,
+                                modifier = Modifier.size(24.dp)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(Spacing.medium))
+                        Column {
+                            Text(
+                                "BLE Protocol Diagnostics",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                "Find the best connection protocol for your device",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Test mode selector (only show when idle)
+            AnimatedVisibility(visible = testState is TestState.Idle) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+                    shape = RoundedCornerShape(16.dp)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(Spacing.medium)
+                    ) {
+                        Text(
+                            "Test Mode",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.small))
+
+                        TestMode.values().forEach { mode ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(
+                                    selected = testMode == mode,
+                                    onClick = { viewModel.setTestMode(mode) }
+                                )
+                                Column(modifier = Modifier.padding(start = 8.dp)) {
+                                    Text(
+                                        mode.displayName,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                    Text(
+                                        mode.description,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // State-dependent content
+            when (val state = testState) {
+                is TestState.Idle -> {
+                    IdleContent(onStartTesting = { viewModel.startTesting() })
+                }
+
+                is TestState.Scanning -> {
+                    ScanningContent(onCancel = { viewModel.cancelTesting() })
+                }
+
+                is TestState.Testing -> {
+                    TestingContent(
+                        currentConfig = state.currentConfig,
+                        progress = state.progress,
+                        total = state.total,
+                        results = results,
+                        onCancel = { viewModel.cancelTesting() }
+                    )
+                }
+
+                is TestState.Completed -> {
+                    CompletedContent(
+                        results = state.results,
+                        onReset = { viewModel.reset() }
+                    )
+                }
+
+                is TestState.Error -> {
+                    ErrorContent(
+                        message = state.message,
+                        onRetry = { viewModel.reset() }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdleContent(onStartTesting: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        Text(
+            "Ready to Test",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.small))
+
+        Text(
+            "This will test different BLE connection protocols to find\nwhich works best with your Vitruvian trainer.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.large))
+
+        Button(
+            onClick = onStartTesting,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            shape = RoundedCornerShape(20.dp)
+        ) {
+            Icon(Icons.Default.PlayArrow, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Start Testing", fontWeight = FontWeight.Bold)
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun ScanningContent(onCancel: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        CircularProgressIndicator(
+            modifier = Modifier.size(64.dp),
+            strokeWidth = 4.dp
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.medium))
+
+        Text(
+            "Scanning for Vitruvian...",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.small))
+
+        Text(
+            "Make sure your trainer is powered on",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.large))
+
+        OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier.height(48.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Text("Cancel")
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun TestingContent(
+    currentConfig: com.example.vitruvianredux.util.ProtocolTester.TestConfig,
+    progress: Int,
+    total: Int,
+    results: List<TestResult>,
+    onCancel: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Progress header
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(Spacing.medium),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    "Testing Protocol $progress of $total",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Spacer(modifier = Modifier.height(Spacing.small))
+
+                LinearProgressIndicator(
+                    progress = { progress.toFloat() / total },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp),
+                    trackColor = MaterialTheme.colorScheme.primaryContainer
+                )
+
+                Spacer(modifier = Modifier.height(Spacing.medium))
+
+                Text(
+                    "Current: ${currentConfig.protocol.displayName}",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    "Delay: ${currentConfig.delay.displayName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.medium))
+
+        // Results list
+        Text(
+            "Results So Far",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.small))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(results) { result ->
+                ResultCard(result = result)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.medium))
+
+        OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
+        ) {
+            Icon(Icons.Default.Close, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Cancel Testing")
+        }
+    }
+}
+
+@Composable
+private fun CompletedContent(
+    results: List<TestResult>,
+    onReset: () -> Unit
+) {
+    val successCount = results.count { it.success }
+    val fastest = results.filter { it.success }.minByOrNull { it.totalTimeMs }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Summary card
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = if (successCount > 0)
+                    MaterialTheme.colorScheme.primaryContainer
+                else
+                    MaterialTheme.colorScheme.errorContainer
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(Spacing.medium),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    if (successCount > 0) Icons.Default.CheckCircle else Icons.Default.Error,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = if (successCount > 0)
+                        MaterialTheme.colorScheme.primary
+                    else
+                        MaterialTheme.colorScheme.error
+                )
+
+                Spacer(modifier = Modifier.height(Spacing.small))
+
+                Text(
+                    "Testing Complete",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Text(
+                    "$successCount of ${results.size} protocols worked",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+
+                if (fastest != null) {
+                    Spacer(modifier = Modifier.height(Spacing.medium))
+                    HorizontalDivider()
+                    Spacer(modifier = Modifier.height(Spacing.medium))
+
+                    Text(
+                        "Recommended Protocol",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "${fastest.protocol.displayName} + ${fastest.delay.displayName}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        "Connection time: ${fastest.totalTimeMs}ms",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.medium))
+
+        Text(
+            "All Results",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.small))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(results.sortedBy { !it.success }) { result ->
+                ResultCard(result = result)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.medium))
+
+        Button(
+            onClick = onReset,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Icon(Icons.Default.Refresh, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Run Again")
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    onRetry: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        Icon(
+            Icons.Default.Error,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.error
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.medium))
+
+        Text(
+            "Testing Failed",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.error
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.small))
+
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.large))
+
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.height(48.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Icon(Icons.Default.Refresh, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Try Again")
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun ResultCard(result: TestResult) {
+    var isPressed by remember { mutableStateOf(false) }
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.98f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "scale"
+    )
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale),
+        colors = CardDefaults.cardColors(
+            containerColor = if (result.success)
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            else
+                MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+        ),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.small),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                if (result.success) Icons.Default.CheckCircle else Icons.Default.Cancel,
+                contentDescription = null,
+                tint = if (result.success)
+                    Color(0xFF22C55E)
+                else
+                    MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(24.dp)
+            )
+
+            Spacer(modifier = Modifier.width(Spacing.small))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    result.protocol.displayName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    "Delay: ${result.delay.displayName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                result.errorMessage?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+
+            if (result.success) {
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        "${result.totalTimeMs}ms",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        "total",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/ProtocolTesterViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/ProtocolTesterViewModel.kt
@@ -1,0 +1,364 @@
+package com.example.vitruvianredux.presentation.viewmodel
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.vitruvianredux.data.ble.VitruvianBleManager
+import com.example.vitruvianredux.data.logger.ConnectionLogger
+import com.example.vitruvianredux.data.repository.BleRepository
+import com.example.vitruvianredux.util.DeviceInfo
+import com.example.vitruvianredux.util.ProtocolTester
+import com.example.vitruvianredux.util.ProtocolTester.TestConfig
+import com.example.vitruvianredux.util.ProtocolTester.TestResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * ViewModel for the Protocol Tester diagnostic tool
+ */
+@HiltViewModel
+class ProtocolTesterViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val bleRepository: BleRepository,
+    private val connectionLogger: ConnectionLogger
+) : ViewModel() {
+
+    // Test state
+    sealed class TestState {
+        object Idle : TestState()
+        object Scanning : TestState()
+        data class Testing(val currentConfig: TestConfig, val progress: Int, val total: Int) : TestState()
+        data class Completed(val results: List<TestResult>) : TestState()
+        data class Error(val message: String) : TestState()
+    }
+
+    private val _testState = MutableStateFlow<TestState>(TestState.Idle)
+    val testState: StateFlow<TestState> = _testState.asStateFlow()
+
+    private val _results = MutableStateFlow<List<TestResult>>(emptyList())
+    val results: StateFlow<List<TestResult>> = _results.asStateFlow()
+
+    private val _currentDeviceName = MutableStateFlow<String?>(null)
+    val currentDeviceName: StateFlow<String?> = _currentDeviceName.asStateFlow()
+
+    private val _testMode = MutableStateFlow(TestMode.RECOMMENDED)
+    val testMode: StateFlow<TestMode> = _testMode.asStateFlow()
+
+    private var testJob: Job? = null
+    private var foundDevice: BluetoothDevice? = null
+
+    enum class TestMode(val displayName: String, val description: String) {
+        QUICK("Quick Test", "Test the 3 most common configurations"),
+        RECOMMENDED("Recommended", "Test 7 recommended configurations"),
+        COMPREHENSIVE("Comprehensive", "Test ALL protocol/delay combinations (35 tests)")
+    }
+
+    /**
+     * Set the test mode
+     */
+    fun setTestMode(mode: TestMode) {
+        _testMode.value = mode
+    }
+
+    /**
+     * Start the protocol testing process
+     */
+    fun startTesting() {
+        testJob?.cancel()
+        _results.value = emptyList()
+
+        testJob = viewModelScope.launch {
+            try {
+                // First, scan for device
+                _testState.value = TestState.Scanning
+                Timber.d("PROTOCOL_TESTER: Starting scan for Vitruvian device...")
+
+                // Get Bluetooth adapter
+                val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+                val bluetoothAdapter = bluetoothManager.adapter
+
+                if (bluetoothAdapter == null || !bluetoothAdapter.isEnabled) {
+                    _testState.value = TestState.Error("Bluetooth is not enabled")
+                    return@launch
+                }
+
+                // Use the existing BLE repository to scan
+                var deviceFound = false
+                val scanJob = launch {
+                    bleRepository.scannedDevices.collect { devices ->
+                        if (devices.isNotEmpty() && !deviceFound) {
+                            deviceFound = true
+                            val device = devices.first()
+                            foundDevice = bluetoothAdapter.getRemoteDevice(device.address)
+                            _currentDeviceName.value = device.name ?: device.address
+                            Timber.d("PROTOCOL_TESTER: Found device: ${device.name}")
+                        }
+                    }
+                }
+
+                // Start scanning
+                bleRepository.startScanning()
+
+                // Wait for device (max 30 seconds)
+                var waitTime = 0
+                while (!deviceFound && waitTime < 30000) {
+                    delay(500)
+                    waitTime += 500
+                }
+
+                scanJob.cancel()
+                bleRepository.stopScanning()
+
+                if (!deviceFound || foundDevice == null) {
+                    _testState.value = TestState.Error("No Vitruvian device found within 30 seconds")
+                    return@launch
+                }
+
+                // Get test configurations based on mode
+                val configs = when (_testMode.value) {
+                    TestMode.QUICK -> listOf(
+                        TestConfig(ProtocolTester.InitProtocol.NO_INIT, ProtocolTester.ConnectionDelay.DELAY_2000MS),
+                        TestConfig(ProtocolTester.InitProtocol.INIT_0x0A_NO_WAIT, ProtocolTester.ConnectionDelay.DELAY_50MS),
+                        TestConfig(ProtocolTester.InitProtocol.INIT_0x0A_WAIT_0x0B, ProtocolTester.ConnectionDelay.DELAY_2000MS)
+                    )
+                    TestMode.RECOMMENDED -> ProtocolTester.generateRecommendedTestConfigs()
+                    TestMode.COMPREHENSIVE -> ProtocolTester.generateAllTestConfigs()
+                }
+
+                Timber.d("PROTOCOL_TESTER: Running ${configs.size} test configurations")
+
+                // Run each test
+                val testResults = mutableListOf<TestResult>()
+                configs.forEachIndexed { index, config ->
+                    _testState.value = TestState.Testing(config, index + 1, configs.size)
+                    Timber.d("PROTOCOL_TESTER: Test ${index + 1}/${configs.size}: ${config.protocol.displayName} + ${config.delay.displayName}")
+
+                    val result = runSingleTest(config)
+                    testResults.add(result)
+                    _results.value = testResults.toList()
+
+                    // Delay between tests to allow device to stabilize
+                    if (index < configs.size - 1) {
+                        delay(3000) // 3 second cooldown between tests
+                    }
+                }
+
+                _testState.value = TestState.Completed(testResults)
+                Timber.d("PROTOCOL_TESTER: Testing complete. ${testResults.count { it.success }}/${testResults.size} succeeded")
+
+            } catch (e: Exception) {
+                Timber.e(e, "PROTOCOL_TESTER: Error during testing")
+                _testState.value = TestState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    /**
+     * Run a single protocol test
+     */
+    private suspend fun runSingleTest(config: TestConfig): TestResult {
+        val device = foundDevice ?: return TestResult(
+            protocol = config.protocol,
+            delay = config.delay,
+            success = false,
+            connectionTimeMs = 0,
+            initTimeMs = 0,
+            errorMessage = "No device available"
+        )
+
+        var connectionTimeMs = 0L
+        var initTimeMs = 0L
+        var errorMessage: String? = null
+        var success = false
+
+        try {
+            // Create a new BLE manager for this test
+            val testManager = VitruvianBleManager(context, connectionLogger)
+
+            // Time the connection
+            val connectStart = System.currentTimeMillis()
+
+            // Connect to device
+            try {
+                testManager.connect(device)
+                    ?.timeout(15000)
+                    ?.retry(2, 200)
+                    ?.useAutoConnect(false)
+                    ?.await()
+
+                connectionTimeMs = System.currentTimeMillis() - connectStart
+                Timber.d("PROTOCOL_TESTER: Connected in ${connectionTimeMs}ms")
+
+                // Apply delay if configured
+                if (config.delay.delayMs > 0) {
+                    Timber.d("PROTOCOL_TESTER: Waiting ${config.delay.delayMs}ms before init")
+                    delay(config.delay.delayMs)
+                }
+
+                // Run init protocol
+                val initStart = System.currentTimeMillis()
+                success = executeInitProtocol(testManager, config.protocol)
+                initTimeMs = System.currentTimeMillis() - initStart
+
+                if (success) {
+                    Timber.d("PROTOCOL_TESTER: Init successful in ${initTimeMs}ms")
+
+                    // Try to send a simple command to verify communication
+                    try {
+                        val verifyResult = testManager.sendCommand(
+                            byteArrayOf(0x0A, 0x00, 0x00, 0x00) // Simple reset command
+                        )
+                        if (verifyResult.isFailure) {
+                            success = false
+                            errorMessage = "Command verification failed"
+                        }
+                    } catch (e: Exception) {
+                        success = false
+                        errorMessage = "Command send failed: ${e.message}"
+                    }
+                } else {
+                    errorMessage = "Init protocol failed"
+                }
+
+            } catch (e: Exception) {
+                connectionTimeMs = System.currentTimeMillis() - connectStart
+                errorMessage = "Connection failed: ${e.message}"
+                Timber.e(e, "PROTOCOL_TESTER: Connection failed")
+            }
+
+            // Clean up
+            try {
+                testManager.stopPolling()
+                testManager.cleanup()
+                testManager.disconnect()?.await()
+            } catch (e: Exception) {
+                Timber.w("PROTOCOL_TESTER: Cleanup exception (expected): ${e.message}")
+            }
+
+            // Extra delay to ensure device is fully disconnected
+            delay(1000)
+
+        } catch (e: Exception) {
+            errorMessage = "Test error: ${e.message}"
+            Timber.e(e, "PROTOCOL_TESTER: Test exception")
+        }
+
+        return TestResult(
+            protocol = config.protocol,
+            delay = config.delay,
+            success = success,
+            connectionTimeMs = connectionTimeMs,
+            initTimeMs = initTimeMs,
+            errorMessage = errorMessage
+        )
+    }
+
+    /**
+     * Execute the init protocol and return success/failure
+     */
+    private suspend fun executeInitProtocol(
+        manager: VitruvianBleManager,
+        protocol: ProtocolTester.InitProtocol
+    ): Boolean {
+        return when (protocol) {
+            ProtocolTester.InitProtocol.NO_INIT -> {
+                // No init needed - success by default
+                true
+            }
+
+            ProtocolTester.InitProtocol.INIT_0x0A_NO_WAIT -> {
+                // Send init command but don't wait for response
+                val cmd = ProtocolTester.buildInitCommandForProtocol(protocol) ?: return false
+                val result = manager.sendCommand(cmd)
+                result.isSuccess
+            }
+
+            ProtocolTester.InitProtocol.INIT_0x0A_WAIT_0x0B -> {
+                // Send init and wait for 0x0B response
+                val cmd = ProtocolTester.buildInitCommandForProtocol(protocol) ?: return false
+                val sendResult = manager.sendCommand(cmd)
+                if (sendResult.isFailure) return false
+
+                // Wait for 0x0B response (5 second timeout)
+                manager.awaitResponse(0x0Bu, 5000L)
+            }
+
+            ProtocolTester.InitProtocol.INIT_0x0A_PLUS_PRESET -> {
+                // Send init command
+                val initCmd = ProtocolTester.buildInitCommandForProtocol(protocol) ?: return false
+                val initResult = manager.sendCommand(initCmd)
+                if (initResult.isFailure) return false
+
+                delay(50) // Brief delay
+
+                // Send preset command
+                val presetCmd = ProtocolTester.buildSecondaryCommandForProtocol(protocol) ?: return false
+                val presetResult = manager.sendCommand(presetCmd)
+                presetResult.isSuccess
+            }
+
+            ProtocolTester.InitProtocol.DOUBLE_0x0A -> {
+                // Send init twice with delay
+                val cmd = ProtocolTester.buildInitCommandForProtocol(protocol) ?: return false
+                val result1 = manager.sendCommand(cmd)
+                if (result1.isFailure) return false
+
+                delay(100)
+
+                val secondCmd = ProtocolTester.buildSecondaryCommandForProtocol(protocol) ?: cmd
+                val result2 = manager.sendCommand(secondCmd)
+                result2.isSuccess
+            }
+        }
+    }
+
+    /**
+     * Cancel ongoing testing
+     */
+    fun cancelTesting() {
+        testJob?.cancel()
+        testJob = null
+        _testState.value = TestState.Idle
+        bleRepository.stopScanning()
+    }
+
+    /**
+     * Generate shareable report
+     */
+    fun generateReport(): String {
+        return ProtocolTester.formatTestReport(
+            results = _results.value,
+            deviceName = _currentDeviceName.value ?: "Unknown",
+            androidVersion = DeviceInfo.androidVersionFull,
+            appVersion = DeviceInfo.appVersionName
+        )
+    }
+
+    /**
+     * Reset to idle state
+     */
+    fun reset() {
+        testJob?.cancel()
+        testJob = null
+        _testState.value = TestState.Idle
+        _results.value = emptyList()
+        _currentDeviceName.value = null
+        foundDevice = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        testJob?.cancel()
+    }
+}

--- a/app/src/main/java/com/example/vitruvianredux/util/ProtocolTester.kt
+++ b/app/src/main/java/com/example/vitruvianredux/util/ProtocolTester.kt
@@ -1,0 +1,217 @@
+package com.example.vitruvianredux.util
+
+import timber.log.Timber
+
+/**
+ * Protocol Tester - Diagnostic tool for testing different BLE initialization protocols
+ *
+ * This helps diagnose connection issues on specific device/firmware combinations by
+ * cycling through different initialization sequences and delays to find what works.
+ */
+object ProtocolTester {
+
+    /**
+     * Different initialization protocol variants to test
+     */
+    enum class InitProtocol(val displayName: String, val description: String) {
+        NO_INIT(
+            "No Init (Default)",
+            "Skip initialization - just connect and start workout directly"
+        ),
+        INIT_0x0A_NO_WAIT(
+            "Init 0x0A (No Wait)",
+            "Send INIT command (0x0A) but don't wait for response"
+        ),
+        INIT_0x0A_WAIT_0x0B(
+            "Init 0x0A + Wait 0x0B",
+            "Send INIT (0x0A) and wait up to 5 seconds for 0x0B response"
+        ),
+        INIT_0x0A_PLUS_PRESET(
+            "Init 0x0A + Preset",
+            "Legacy web app protocol: Send 0x0A then 0x11 preset frame"
+        ),
+        INIT_DOUBLE_0x0A(
+            "Double Init 0x0A",
+            "Send INIT command twice with delay between"
+        )
+    }
+
+    /**
+     * Different delay configurations to test after connection
+     */
+    enum class ConnectionDelay(val displayName: String, val delayMs: Long) {
+        NONE("No Delay", 0L),
+        DELAY_50MS("50ms", 50L),
+        DELAY_100MS("100ms", 100L),
+        DELAY_250MS("250ms", 250L),
+        DELAY_500MS("500ms", 500L),
+        DELAY_1000MS("1 second", 1000L),
+        DELAY_2000MS("2 seconds", 2000L)
+    }
+
+    /**
+     * Result of a single protocol test
+     */
+    data class TestResult(
+        val protocol: InitProtocol,
+        val delay: ConnectionDelay,
+        val success: Boolean,
+        val connectionTimeMs: Long,
+        val initTimeMs: Long,
+        val errorMessage: String? = null,
+        val notes: String? = null
+    ) {
+        val totalTimeMs: Long get() = connectionTimeMs + initTimeMs
+
+        fun toFormattedString(): String = buildString {
+            append("${protocol.displayName} + ${delay.displayName}: ")
+            if (success) {
+                append("✅ SUCCESS (${totalTimeMs}ms)")
+            } else {
+                append("❌ FAILED")
+                errorMessage?.let { append(" - $it") }
+            }
+        }
+    }
+
+    /**
+     * Protocol test configuration
+     */
+    data class TestConfig(
+        val protocol: InitProtocol,
+        val delay: ConnectionDelay,
+        val timeout: Long = 10000L
+    )
+
+    /**
+     * Generate all test configurations to try
+     */
+    fun generateAllTestConfigs(): List<TestConfig> {
+        val configs = mutableListOf<TestConfig>()
+
+        // For each protocol, test with different delays
+        InitProtocol.values().forEach { protocol ->
+            ConnectionDelay.values().forEach { delay ->
+                configs.add(TestConfig(protocol, delay))
+            }
+        }
+
+        return configs
+    }
+
+    /**
+     * Generate a recommended subset of test configurations (faster testing)
+     */
+    fun generateRecommendedTestConfigs(): List<TestConfig> {
+        return listOf(
+            // Most likely to work - current default
+            TestConfig(InitProtocol.NO_INIT, ConnectionDelay.DELAY_2000MS),
+            TestConfig(InitProtocol.NO_INIT, ConnectionDelay.DELAY_500MS),
+            TestConfig(InitProtocol.NO_INIT, ConnectionDelay.NONE),
+
+            // Legacy protocols that might work on older firmware
+            TestConfig(InitProtocol.INIT_0x0A_NO_WAIT, ConnectionDelay.DELAY_50MS),
+            TestConfig(InitProtocol.INIT_0x0A_WAIT_0x0B, ConnectionDelay.DELAY_2000MS),
+            TestConfig(InitProtocol.INIT_0x0A_PLUS_PRESET, ConnectionDelay.DELAY_100MS),
+
+            // Double init might help with flaky connections
+            TestConfig(InitProtocol.DOUBLE_0x0A, ConnectionDelay.DELAY_500MS)
+        )
+    }
+
+    /**
+     * Build the init command bytes based on protocol
+     */
+    fun buildInitCommandForProtocol(protocol: InitProtocol): ByteArray? {
+        return when (protocol) {
+            InitProtocol.NO_INIT -> null
+            InitProtocol.INIT_0x0A_NO_WAIT,
+            InitProtocol.INIT_0x0A_WAIT_0x0B,
+            InitProtocol.DOUBLE_0x0A -> ProtocolBuilder.buildInitCommand()
+            InitProtocol.INIT_0x0A_PLUS_PRESET -> ProtocolBuilder.buildInitCommand()
+        }
+    }
+
+    /**
+     * Build the secondary command (if any) based on protocol
+     */
+    fun buildSecondaryCommandForProtocol(protocol: InitProtocol): ByteArray? {
+        return when (protocol) {
+            InitProtocol.INIT_0x0A_PLUS_PRESET -> ProtocolBuilder.buildInitPreset()
+            InitProtocol.DOUBLE_0x0A -> ProtocolBuilder.buildInitCommand()
+            else -> null
+        }
+    }
+
+    /**
+     * Check if protocol requires waiting for response
+     */
+    fun requiresResponseWait(protocol: InitProtocol): Boolean {
+        return protocol == InitProtocol.INIT_0x0A_WAIT_0x0B
+    }
+
+    /**
+     * Get expected response opcode (if any)
+     */
+    fun getExpectedResponseOpcode(protocol: InitProtocol): UByte? {
+        return when (protocol) {
+            InitProtocol.INIT_0x0A_WAIT_0x0B -> 0x0Bu
+            else -> null
+        }
+    }
+
+    /**
+     * Format test results as a shareable report
+     */
+    fun formatTestReport(
+        results: List<TestResult>,
+        deviceName: String,
+        androidVersion: String,
+        appVersion: String
+    ): String = buildString {
+        appendLine("═══════════════════════════════════════════════════════")
+        appendLine("       VITRUVIAN PROTOCOL TESTER REPORT")
+        appendLine("═══════════════════════════════════════════════════════")
+        appendLine()
+        appendLine("Generated: ${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US).format(java.util.Date())}")
+        appendLine("Device: $deviceName")
+        appendLine("Android: $androidVersion")
+        appendLine("App Version: $appVersion")
+        appendLine()
+        appendLine("─── TEST RESULTS ───")
+        appendLine()
+
+        val successfulResults = results.filter { it.success }
+        val failedResults = results.filter { !it.success }
+
+        appendLine("✅ Successful configurations: ${successfulResults.size}")
+        successfulResults.forEach { result ->
+            appendLine("  • ${result.protocol.displayName} + ${result.delay.displayName}")
+            appendLine("    Time: ${result.totalTimeMs}ms (connect: ${result.connectionTimeMs}ms, init: ${result.initTimeMs}ms)")
+            result.notes?.let { appendLine("    Notes: $it") }
+        }
+
+        appendLine()
+        appendLine("❌ Failed configurations: ${failedResults.size}")
+        failedResults.forEach { result ->
+            appendLine("  • ${result.protocol.displayName} + ${result.delay.displayName}")
+            appendLine("    Error: ${result.errorMessage ?: "Unknown error"}")
+        }
+
+        appendLine()
+        appendLine("─── RECOMMENDATION ───")
+        appendLine()
+
+        if (successfulResults.isNotEmpty()) {
+            val fastest = successfulResults.minByOrNull { it.totalTimeMs }
+            appendLine("Recommended protocol: ${fastest?.protocol?.displayName} + ${fastest?.delay?.displayName}")
+            appendLine("This configuration connected fastest at ${fastest?.totalTimeMs}ms")
+        } else {
+            appendLine("No successful configurations found.")
+            appendLine("Please share this report for further analysis.")
+        }
+
+        appendLine()
+        appendLine("═══════════════════════════════════════════════════════")
+    }
+}


### PR DESCRIPTION
Implements a diagnostic tool that cycles through different BLE initialization protocols to help identify which configuration works best for specific devices.

This addresses issue #170 where a user experiences persistent connection issues on a Pixel 7 Pro with Android 16 Beta.

Changes:
- Add ProtocolTester utility with 5 different init protocol variants
- Add ProtocolTesterViewModel to orchestrate testing
- Add ProtocolTesterScreen UI with test mode selection and results display
- Integrate into Settings -> Developer Tools section
- Support Quick, Recommended, and Comprehensive test modes
- Generate shareable test reports for debugging

Protocol variants tested:
- No Init (current default)
- Init 0x0A without wait
- Init 0x0A + wait for 0x0B response
- Init 0x0A + preset frame (legacy)
- Double Init 0x0A