### PR TITLE
Fix workout connection disconnect after start

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
@@ -616,6 +616,14 @@ class VitruvianBleManager(
                         Timber.d("🔥 REP NOTIFICATION CALLBACK FIRED! Data size: ${data.value?.size ?: 0} bytes")
                         handleRepNotification(data)
                     }
+                } else if (characteristic.uuid == BleConstants.MONITOR_CHAR_UUID) {
+                    // CRITICAL FIX: Use notifications for monitor data instead of read polling
+                    // This fixes the Android 16 Pixel disconnect issue where readCharacteristic()
+                    // calls fail silently, jamming the BLE queue and causing supervision timeout
+                    setNotificationCallback(characteristic).with { _, data ->
+                        Timber.v("📊 MONITOR NOTIFICATION RECEIVED! Data size: ${data.value?.size ?: 0} bytes")
+                        handleMonitorData(data)
+                    }
                 } else if (characteristic.uuid == BleConstants.VERSION_CHAR_UUID) {
                     // Special handler for VERSION characteristic - log raw hex for reverse engineering
                     setNotificationCallback(characteristic).with { _, data ->
@@ -671,9 +679,15 @@ class VitruvianBleManager(
     }
     
     /**
-     * Start polling monitor characteristic every 100ms
-     * This is how the official app reads position/force data
-     * Called when workout starts
+     * Enable monitor data reception for workouts
+     *
+     * CRITICAL FIX (Android 16 Pixel disconnect issue):
+     * Monitor data now flows via BLE notifications (set up in initialize()) instead of
+     * readCharacteristic() polling. The old polling approach caused silent read failures
+     * on Pixel 7/Android 16, jamming the BLE queue and triggering 5-second supervision timeout.
+     *
+     * Notifications are already enabled during connection via NOTIFY_CHAR_UUIDS.
+     * This method just sets up the handle detection state for workout tracking.
      *
      * @param forAutoStart If true, enables handle detection with WaitingForRest state (for Just Lift auto-start).
      *                     If false, skips handle state initialization (for active workout monitoring).
@@ -689,35 +703,21 @@ class VitruvianBleManager(
             _handleState.value = HandleState.WaitingForRest
             forceAboveGrabThresholdStart = null
             forceBelowReleaseThresholdStart = null
-            Timber.d("Starting monitor polling for AUTO-START - waiting for handles at rest (pos < ${HANDLE_REST_THRESHOLD})")
+            Timber.d("Monitor data enabled for AUTO-START - waiting for handles at rest (pos < ${HANDLE_REST_THRESHOLD})")
         } else {
             // Active workout - set to Grabbed since workout is already running
             _handleState.value = HandleState.Grabbed
-            Timber.d("Starting monitor polling for ACTIVE WORKOUT")
+            Timber.d("Monitor data enabled for ACTIVE WORKOUT")
         }
 
+        // Cancel any legacy polling job (should not be running, but clean up just in case)
         monitorPollingJob?.cancel()
-        monitorPollingJob = pollingScope.launch {
-            // WEB APP POLLING: 100ms (10Hz) - verified from exerciselibrary & workoutmachineappfree
-            // Previous 16ms (60Hz) was too aggressive and may have overwhelmed BLE queue
-            Timber.d("Starting monitor polling (100ms interval / 10Hz) - matches web app")
-            while (isActive) {
-                try {
-                    monitorCharacteristic?.let { char ->
-                        // MUST use .with() and .enqueue() together
-                        readCharacteristic(char)
-                            .with { _, data ->
-                                Timber.v("Monitor read callback fired!")
-                                handleMonitorData(data)
-                            }
-                            .enqueue()
-                    }
-                    delay(100) // Poll every 100ms (10Hz) - matches web app
-                } catch (e: Exception) {
-                    Timber.e(e, "Error in monitor polling")
-                }
-            }
-        }
+        monitorPollingJob = null
+
+        // NOTE: Monitor data now arrives via BLE notifications (configured in initialize()).
+        // No polling loop needed - handleMonitorData() is called directly by the notification callback.
+        // This prevents the BLE queue jamming that caused Android 16 Pixel disconnects.
+        Timber.i("✅ Monitor data reception active (via notifications, not polling)")
     }
     
     /**

--- a/app/src/main/java/com/example/vitruvianredux/util/BleConstants.kt
+++ b/app/src/main/java/com/example/vitruvianredux/util/BleConstants.kt
@@ -40,7 +40,8 @@ object BleConstants {
         REPS_CHAR_UUID,
         HEURISTIC_CHAR_UUID,
         BLE_UPDATE_REQUEST_CHAR_UUID,
-        UNKNOWN_AUTH_CHAR_UUID  // Web apps subscribe to this
+        UNKNOWN_AUTH_CHAR_UUID,  // Web apps subscribe to this
+        SAMPLE_CHAR_UUID  // Monitor data - use notifications instead of read polling (fixes Android 16 Pixel disconnect)
     )
 
     // Official app workout command characteristics (discovered from HCI logs)


### PR DESCRIPTION
Root cause: On Pixel 7/Android 16, readCharacteristic() calls fail silently (callback never fires). The 100ms polling loop queued 10 read operations/sec, jamming the BLE GATT queue. Heartbeat writes couldn't get through, resulting in no BLE traffic → 5-second supervision timeout → disconnect.

The fix:
1. Add SAMPLE_CHAR_UUID to NOTIFY_CHAR_UUIDS so notifications are enabled for the monitor characteristic during connection
2. Add notification callback in initialize() to route monitor data to handleMonitorData() instead of relying on read callbacks
3. Remove the readCharacteristic() polling loop from startMonitorPolling()

This is a surgical fix - monitor data now flows via push notifications (which were already working) instead of pull reads (which were failing).