### PR TITLE
fix: add legacy 6-byte rep notification support for Samsung devices (…

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
@@ -1584,61 +1584,88 @@ class VitruvianBleManager(
     /**
      * Handle rep notification data
      *
-     * Official App Reps Packet Structure (24 bytes, Little Endian):
+     * Supports TWO packet formats for backwards compatibility (Issue #187):
+     *
+     * LEGACY FORMAT (6+ bytes, used in Beta 4):
+     * - Bytes 0-1: topCounter (u16) - concentric completions
+     * - Bytes 2-3: (unused)
+     * - Bytes 4-5: completeCounter (u16) - eccentric completions
+     *
+     * OFFICIAL APP FORMAT (24 bytes, Little Endian):
      * - Bytes 0-3:   up (Int/u32) - up counter (concentric completions)
      * - Bytes 4-7:   down (Int/u32) - down counter (eccentric completions)
      * - Bytes 8-11:  rangeTop (Float) - maximum ROM boundary
      * - Bytes 12-15: rangeBottom (Float) - minimum ROM boundary
-     * - Bytes 16-17: repsRomCount (Short/u16) - Warmup reps with proper ROM - USE FOR WARMUP DISPLAY
+     * - Bytes 16-17: repsRomCount (Short/u16) - Warmup reps with proper ROM
      * - Bytes 18-19: repsRomTotal (Short/u16) - Total reps regardless of ROM
-     * - Bytes 20-21: repsSetCount (Short/u16) - WORKING SET REP COUNT - display this!
+     * - Bytes 20-21: repsSetCount (Short/u16) - WORKING SET REP COUNT
      * - Bytes 22-23: repsSetTotal (Short/u16) - Total reps in set
      */
     private fun handleRepNotification(data: Data) {
         try {
             val bytes = data.value ?: return
 
-            if (bytes.size < 24) {
-                Timber.w("Rep notification too short: ${bytes.size} bytes (expected 24)")
+            if (bytes.size < 6) {
+                Timber.w("Rep notification too short: ${bytes.size} bytes (minimum 6)")
                 return
             }
 
-            // Parse full 24-byte packet according to official app structure
             val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
 
-            // u32 counters at offsets 0 and 4
-            val upCounter = buffer.getInt(0)
-            val downCounter = buffer.getInt(4)
+            val repData: RepNotification
 
-            // Float ROM boundaries at offsets 8 and 12
-            val rangeTop = buffer.getFloat(8)
-            val rangeBottom = buffer.getFloat(12)
+            if (bytes.size >= 24) {
+                // FULL 24-byte packet - parse all fields
+                val upCounter = buffer.getInt(0)
+                val downCounter = buffer.getInt(4)
+                val rangeTop = buffer.getFloat(8)
+                val rangeBottom = buffer.getFloat(12)
+                val repsRomCount = buffer.getShort(16).toInt() and 0xFFFF
+                val repsRomTotal = buffer.getShort(18).toInt() and 0xFFFF
+                val repsSetCount = buffer.getShort(20).toInt() and 0xFFFF
+                val repsSetTotal = buffer.getShort(22).toInt() and 0xFFFF
 
-            // u16 rep counts at offsets 16, 18, 20, 22
-            val repsRomCount = buffer.getShort(16).toInt() and 0xFFFF   // Warmup reps (proper ROM)
-            val repsRomTotal = buffer.getShort(18).toInt() and 0xFFFF  // Total reps (any ROM)
-            val repsSetCount = buffer.getShort(20).toInt() and 0xFFFF  // WORKING SET REPS - display this!
-            val repsSetTotal = buffer.getShort(22).toInt() and 0xFFFF  // Total set reps
+                Timber.d("Rep notification (24-byte format):")
+                Timber.d("  up=$upCounter, down=$downCounter")
+                Timber.d("  repsRomCount=$repsRomCount (warmup), repsSetCount=$repsSetCount (working)")
+                Timber.d("  hex=${bytes.joinToString(" ") { "%02X".format(it) }}")
 
-            Timber.d("Rep notification FULL PARSE:")
-            Timber.d("  up=$upCounter, down=$downCounter")
-            Timber.d("  rangeTop=$rangeTop, rangeBottom=$rangeBottom")
-            Timber.d("  repsRomCount=$repsRomCount (warmup), repsRomTotal=$repsRomTotal")
-            Timber.d("  repsSetCount=$repsSetCount (WORKING), repsSetTotal=$repsSetTotal")
-            Timber.d("  hex=${bytes.joinToString(" ") { "%02X".format(it) }}")
+                repData = RepNotification(
+                    topCounter = upCounter,
+                    completeCounter = downCounter,
+                    repsRomCount = repsRomCount,
+                    repsSetCount = repsSetCount,
+                    rangeTop = rangeTop,
+                    rangeBottom = rangeBottom,
+                    rawData = bytes,
+                    timestamp = System.currentTimeMillis(),
+                    isLegacyFormat = false
+                )
+            } else {
+                // LEGACY 6-byte packet (Beta 4 format) - parse u16 counters
+                // This handles Samsung devices and older firmware that may send shorter packets
+                val topCounter = buffer.getShort(0).toInt() and 0xFFFF
+                val completeCounter = buffer.getShort(4).toInt() and 0xFFFF
 
-            val repData = RepNotification(
-                topCounter = upCounter,          // Use full u32 up counter
-                completeCounter = downCounter,   // Use full u32 down counter
-                repsRomCount = repsRomCount,     // Warmup reps (proper ROM)
-                repsSetCount = repsSetCount,     // WORKING SET REPS - this is what official app displays!
-                rangeTop = rangeTop,
-                rangeBottom = rangeBottom,
-                rawData = bytes,
-                timestamp = System.currentTimeMillis()
-            )
+                Timber.w("Rep notification (LEGACY 6-byte format - Issue #187 fallback):")
+                Timber.w("  top=$topCounter, complete=$completeCounter")
+                Timber.w("  hex=${bytes.joinToString(" ") { "%02X".format(it) }}")
+
+                repData = RepNotification(
+                    topCounter = topCounter,
+                    completeCounter = completeCounter,
+                    repsRomCount = 0,  // Not available in legacy format
+                    repsSetCount = 0,  // Not available in legacy format
+                    rangeTop = 0f,
+                    rangeBottom = 0f,
+                    rawData = bytes,
+                    timestamp = System.currentTimeMillis(),
+                    isLegacyFormat = true
+                )
+            }
+
             val emitted = _repEvents.tryEmit(repData)
-            Timber.d("🔥 Emitted rep event: success=$emitted, subscribers=${_repEvents.subscriptionCount.value}")
+            Timber.d("🔥 Emitted rep event: success=$emitted, subscribers=${_repEvents.subscriptionCount.value}, legacy=${repData.isLegacyFormat}")
         } catch (e: Exception) {
             Timber.e(e, "Error parsing rep notification")
         }
@@ -1707,7 +1734,13 @@ enum class HandleState {
  * Rep notification data class
  * Parsed from device notifications on characteristic 8308f2a6-0875-4a94-a86f-5c5c5e1b068a
  *
- * Official App 24-byte Structure:
+ * Supports TWO formats (Issue #187):
+ *
+ * LEGACY FORMAT (6 bytes, Beta 4 compatible):
+ * - Uses topCounter/completeCounter for rep counting
+ * - isLegacyFormat = true
+ *
+ * OFFICIAL APP FORMAT (24 bytes):
  * - topCounter (u32): Concentric/up phase completions
  * - completeCounter (u32): Eccentric/down phase completions
  * - rangeTop (float): Maximum ROM boundary
@@ -1716,6 +1749,7 @@ enum class HandleState {
  * - repsRomTotal (u16): Total reps regardless of ROM
  * - repsSetCount (u16): Working set rep count - USE FOR WORKING REPS DISPLAY
  * - repsSetTotal (u16): Total reps in set
+ * - isLegacyFormat = false
  */
 data class RepNotification(
     val topCounter: Int,        // u32: Concentric completions (up counter)
@@ -1725,7 +1759,8 @@ data class RepNotification(
     val rangeTop: Float = 0f,   // ROM max boundary
     val rangeBottom: Float = 0f, // ROM min boundary
     val rawData: ByteArray,
-    val timestamp: Long
+    val timestamp: Long,
+    val isLegacyFormat: Boolean = false  // True if parsed from 6-byte legacy packet (Issue #187)
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -1741,6 +1776,7 @@ data class RepNotification(
         if (rangeBottom != other.rangeBottom) return false
         if (!rawData.contentEquals(other.rawData)) return false
         if (timestamp != other.timestamp) return false
+        if (isLegacyFormat != other.isLegacyFormat) return false
 
         return true
     }
@@ -1754,6 +1790,7 @@ data class RepNotification(
         result = 31 * result + rangeBottom.hashCode()
         result = 31 * result + rawData.contentHashCode()
         result = 31 * result + timestamp.hashCode()
+        result = 31 * result + isLegacyFormat.hashCode()
         return result
     }
 }

--- a/app/src/main/java/com/example/vitruvianredux/domain/usecase/RepCounterFromMachine.kt
+++ b/app/src/main/java/com/example/vitruvianredux/domain/usecase/RepCounterFromMachine.kt
@@ -176,15 +176,24 @@ class RepCounterFromMachine {
     /**
      * Process rep data from machine with visual feedback timing.
      *
-     * For WARMUP reps: Uses ROM counter directly (no pending animation)
-     * For WORKING reps: Shows pending (grey) at TOP, confirmed (colored) at BOTTOM
+     * Supports TWO modes (Issue #187):
      *
-     * @param repsRomCount Machine's ROM rep count (warmup reps)
-     * @param repsSetCount Machine's set rep count (working reps)
+     * MODERN MODE (isLegacyFormat=false):
+     * - Uses repsRomCount for warmup reps
+     * - Uses repsSetCount for working reps
+     * - up/down counters for visual pending feedback
+     *
+     * LEGACY MODE (isLegacyFormat=true, Beta 4 compatible):
+     * - Uses topCounter (up) increments to count reps directly
+     * - This is the method that worked in Beta 4 and handles Samsung devices
+     *
+     * @param repsRomCount Machine's ROM rep count (warmup reps) - 0 for legacy
+     * @param repsSetCount Machine's set rep count (working reps) - 0 for legacy
      * @param up Directional counter - increments at TOP (concentric peak)
      * @param down Directional counter - increments at BOTTOM (eccentric valley)
      * @param posA Position A for range calibration
      * @param posB Position B for range calibration
+     * @param isLegacyFormat True if using 6-byte legacy packet format (Issue #187)
      */
     fun process(
         repsRomCount: Int,
@@ -192,15 +201,100 @@ class RepCounterFromMachine {
         up: Int = 0,
         down: Int = 0,
         posA: Int = 0,
-        posB: Int = 0
+        posB: Int = 0,
+        isLegacyFormat: Boolean = false
     ) {
         // DIAGNOSTIC: Log full state for debugging rep counting issues
-        // The "warmup gate" (warmupReps >= warmupTarget) MUST pass for working reps to count
         val warmupGateOpen = warmupReps >= warmupTarget
-        Timber.d("Rep process: ROM=$repsRomCount, Set=$repsSetCount, up=$up, down=$down, pending=$hasPendingRep")
+        Timber.d("Rep process: ROM=$repsRomCount, Set=$repsSetCount, up=$up, down=$down, pending=$hasPendingRep, legacy=$isLegacyFormat")
         Timber.d("  Warmup gate: warmupReps=$warmupReps, warmupTarget=$warmupTarget, gate=${if (warmupGateOpen) "OPEN" else "BLOCKED"}")
         Timber.d("  Working: workingReps=$workingReps, workingTarget=$workingTarget")
 
+        if (isLegacyFormat) {
+            // LEGACY MODE: Count reps based on topCounter increments (Beta 4 method)
+            // This is the proven method that works with Samsung devices and older firmware
+            processLegacy(up, down, posA, posB)
+        } else {
+            // MODERN MODE: Use machine-provided repsRomCount/repsSetCount
+            processModern(repsRomCount, repsSetCount, up, down, posA, posB)
+        }
+    }
+
+    /**
+     * LEGACY rep counting (Beta 4 method) - counts reps when topCounter increments.
+     * Used when machine sends 6-byte packets without repsRomCount/repsSetCount fields.
+     */
+    private fun processLegacy(up: Int, down: Int, posA: Int, posB: Int) {
+        if (lastTopCounter != null) {
+            val topDelta = calculateDelta(lastTopCounter!!, up)
+            if (topDelta > 0) {
+                recordTopPosition(posA, posB)
+
+                // Count the rep at TOP of movement (matches Beta 4 / official app behavior)
+                val totalReps = warmupReps + workingReps + 1
+                if (totalReps <= warmupTarget) {
+                    warmupReps++
+                    Timber.d("📈 LEGACY: Warmup rep $warmupReps (top counter increment)")
+                    onRepEvent?.invoke(
+                        RepEvent(
+                            type = RepType.WARMUP_COMPLETED,
+                            warmupCount = warmupReps,
+                            workingCount = workingReps
+                        )
+                    )
+                    if (warmupReps == warmupTarget) {
+                        onRepEvent?.invoke(
+                            RepEvent(
+                                type = RepType.WARMUP_COMPLETE,
+                                warmupCount = warmupReps,
+                                workingCount = workingReps
+                            )
+                        )
+                    }
+                } else {
+                    workingReps++
+                    Timber.d("💪 LEGACY: Working rep $workingReps (top counter increment)")
+                    onRepEvent?.invoke(
+                        RepEvent(
+                            type = RepType.WORKING_COMPLETED,
+                            warmupCount = warmupReps,
+                            workingCount = workingReps
+                        )
+                    )
+
+                    // Check if target reached (unless AMRAP or Just Lift)
+                    if (!isJustLift && !isAMRAP && workingTarget > 0 && workingReps >= workingTarget) {
+                        Timber.d("⚠️ LEGACY: shouldStop set to TRUE (target reached)")
+                        shouldStop = true
+                        onRepEvent?.invoke(
+                            RepEvent(
+                                type = RepType.WORKOUT_COMPLETE,
+                                warmupCount = warmupReps,
+                                workingCount = workingReps
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        // Track bottom position for calibration
+        if (lastCompleteCounter != null) {
+            val downDelta = calculateDelta(lastCompleteCounter!!, down)
+            if (downDelta > 0) {
+                recordBottomPosition(posA, posB)
+            }
+        }
+
+        lastTopCounter = up
+        lastCompleteCounter = down
+    }
+
+    /**
+     * MODERN rep counting - uses machine-provided repsRomCount/repsSetCount.
+     * This is the official app method with pending rep visual feedback.
+     */
+    private fun processModern(repsRomCount: Int, repsSetCount: Int, up: Int, down: Int, posA: Int, posB: Int) {
         // Track UP movement - for working reps, show PENDING (grey) at TOP
         if (lastTopCounter != null) {
             val upDelta = calculateDelta(lastTopCounter!!, up)

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -655,20 +655,24 @@ class MainViewModel @Inject constructor(
     /**
      * Handle rep notifications provided by the machine.
      *
-     * CRITICAL: Uses device-provided repsRomCount and repsSetCount directly (official app method).
-     * This ensures rep counting matches exactly what the firmware reports.
+     * Supports TWO modes (Issue #187):
+     * - MODERN: Uses repsRomCount/repsSetCount from 24-byte packets
+     * - LEGACY: Uses topCounter increments from 6-byte packets (Beta 4 method)
+     *
+     * The isLegacyFormat flag determines which counting method to use.
      */
     private fun handleRepNotification(notification: com.example.vitruvianredux.data.ble.RepNotification) {
         val currentPositions = _currentMetric.value
-        // Use machine's ROM and Set counters directly (official app method)
-        // This prevents "getting ready" pull from being counted as a rep
+
+        // Issue #187: Pass legacy flag to enable Beta 4 counting for Samsung devices
         repCounter.process(
-            repsRomCount = notification.repsRomCount,   // Machine's warmup rep count
-            repsSetCount = notification.repsSetCount,   // Machine's working rep count
-            up = notification.topCounter,               // For position calibration
+            repsRomCount = notification.repsRomCount,   // Machine's warmup rep count (0 for legacy)
+            repsSetCount = notification.repsSetCount,   // Machine's working rep count (0 for legacy)
+            up = notification.topCounter,               // For position calibration / legacy counting
             down = notification.completeCounter,        // For position calibration
             posA = currentPositions?.positionA ?: 0,
-            posB = currentPositions?.positionB ?: 0
+            posB = currentPositions?.positionB ?: 0,
+            isLegacyFormat = notification.isLegacyFormat  // Use Beta 4 counting if legacy packet
         )
         // Update rep ranges for position bars visualization
         _repRanges.value = repCounter.getRepRanges()


### PR DESCRIPTION
…Issue #187)

Root Cause Analysis:
Beta 6 changed rep notification parsing from 6 bytes to 24 bytes, and switched from using topCounter increments (Beta 4 method) to using repsRomCount/repsSetCount fields for rep counting. This broke rep counting for Samsung devices and older firmware that may send shorter packets.

Changes:
1. VitruvianBleManager: Support both 6-byte and 24-byte rep notification formats
   - 6-byte packets (legacy): Parse topCounter/completeCounter as u16
   - 24-byte packets (modern): Parse full official app structure
   - Add isLegacyFormat flag to RepNotification

2. RepCounterFromMachine: Add dual counting mode
   - Legacy mode: Count reps when topCounter increments (Beta 4 method)
   - Modern mode: Use repsRomCount/repsSetCount from machine
   - Split into processLegacy() and processModern() for clarity

3. MainViewModel: Pass isLegacyFormat flag to rep counter

This fix maintains backwards compatibility with Beta 4 behavior while supporting the new 24-byte packet format when available.