### PR TITLE
Fix exercise stopping with stall sensing

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
+++ b/app/src/main/java/com/example/vitruvianredux/data/ble/VitruvianBleManager.kt
@@ -97,9 +97,10 @@ class VitruvianBleManager(
     // Using abs() would make all jitter positive, averaging to ~20mm/s and preventing stall detection
     @Volatile private var smoothedVelocityA = 0.0
     @Volatile private var smoothedVelocityB = 0.0
-    // EMA alpha: 0.15 = aggressive smoothing for high-extension exercises (shoulder press)
-    // Lower alpha reduces jitter impact but makes velocity response slightly slower
-    private val VELOCITY_SMOOTHING_ALPHA = 0.15
+    // EMA alpha: 0.3 = balanced smoothing (faster response during direction changes)
+    // Higher alpha reduces zero-crossing dwell time during eccentric/concentric transitions
+    // which prevents false stall detection during controlled tempo movements
+    private val VELOCITY_SMOOTHING_ALPHA = 0.3
 
     // Diagnostic info exposed for Protocol Tester
     @Volatile var detectedFirmwareVersion: String? = null

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -2777,8 +2777,9 @@ class MainViewModel @Inject constructor(
         private const val AUTO_STOP_DURATION_SECONDS = 2.5f  // User observation: ~2.5 seconds (snappier than 5s)
 
         // Velocity-based stall detection constants (Issue #204)
-        // Threshold: 30mm/s - reduced for better sensitivity (EMA smoothing handles noise)
-        private const val STALL_VELOCITY_THRESHOLD = 30.0  // Velocity below this = "not moving" (mm/s)
+        // Threshold: 25mm/s - matches official app behavior
+        // Combined with faster EMA (alpha=0.3), this prevents false stall during direction changes
+        private const val STALL_VELOCITY_THRESHOLD = 25.0  // Velocity below this = "not moving" (mm/s)
         private const val STALL_DURATION_SECONDS = 5.0f    // How long to stall before auto-stop triggers
         // Min position to consider handles "in use" (Issue #204 fix)
         // Prevents false auto-stop when handles are at rest position near 0


### PR DESCRIPTION
The stall sensing was triggering during slow eccentric movements due to two issues:

1. EMA smoothing (alpha=0.15) was too aggressive, causing the smoothed velocity to stay low during direction changes as it crossed through zero
2. The 30 mm/s threshold was higher than the official app's 25 mm/s

Changes:
- Increased EMA alpha from 0.15 to 0.3 for faster response during direction changes
- Set stall velocity threshold to 25 mm/s to match official app behavior

This prevents exercises from abruptly stopping during the eccentric phase while still detecting genuine stalls when the bar is resting (e.g., bench press).