### PR TITLE
Fix eccentric load slider resetting to default

### DIFF
--- a/app/src/main/java/com/example/vitruvianredux/presentation/screen/SingleExerciseScreen.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/screen/SingleExerciseScreen.kt
@@ -41,6 +41,7 @@ fun SingleExerciseScreen(
     val enableVideoPlayback by viewModel.enableVideoPlayback.collectAsState()
     val isAutoConnecting by viewModel.isAutoConnecting.collectAsState()
     val connectionError by viewModel.connectionError.collectAsState()
+    val sessionEccentricLoad by viewModel.sessionEccentricLoad.collectAsState()
 
     var exerciseToConfig by remember { mutableStateOf<RoutineExercise?>(null) }
     var isLoadingDefaults by remember { mutableStateOf(false) }
@@ -166,7 +167,7 @@ fun SingleExerciseScreen(
                                     perSetRestTime = savedDefaults.perSetRestTime
                                 )
                             } else {
-                                // No saved defaults - use system defaults
+                                // No saved defaults - use system defaults with session eccentric load
                                 RoutineExercise(
                                     id = UUID.randomUUID().toString(),
                                     exercise = exercise,
@@ -177,7 +178,7 @@ fun SingleExerciseScreen(
                                     progressionKg = 0f,
                                     setRestSeconds = listOf(60, 60, 60),
                                     workoutType = WorkoutType.Program(ProgramMode.OldSchool),
-                                    eccentricLoad = EccentricLoad.LOAD_100,
+                                    eccentricLoad = sessionEccentricLoad,
                                     echoLevel = EchoLevel.HARDER
                                 )
                             }

--- a/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/vitruvianredux/presentation/viewmodel/MainViewModel.kt
@@ -221,6 +221,11 @@ class MainViewModel @Inject constructor(
     private val _bodyweightTimerState = MutableStateFlow<Pair<Int, Int>?>(null)
     val bodyweightTimerState: StateFlow<Pair<Int, Int>?> = _bodyweightTimerState.asStateFlow()
 
+    // Session-level eccentric load: persists across exercises within a workout session
+    // Used as fallback when an exercise has no saved defaults
+    private val _sessionEccentricLoad = MutableStateFlow(EccentricLoad.LOAD_100)
+    val sessionEccentricLoad: StateFlow<EccentricLoad> = _sessionEccentricLoad.asStateFlow()
+
     // Weekly Programs
     val weeklyPrograms: StateFlow<List<com.example.vitruvianredux.data.local.WeeklyProgramWithDays>> =
         workoutRepository.getAllPrograms()
@@ -1137,6 +1142,12 @@ class MainViewModel @Inject constructor(
     fun updateWorkoutParameters(params: WorkoutParameters) {
         Timber.d("⚖️ updateWorkoutParameters: weight=${params.weightPerCableKg} kg (${params.weightPerCableKg * 2.20462f} lbs)")
         _workoutParameters.value = params
+
+        // Update session-level eccentric load for cross-exercise persistence
+        val workoutType = params.workoutType
+        if (workoutType is WorkoutType.Echo) {
+            _sessionEccentricLoad.value = workoutType.eccentricLoad
+        }
 
         // Track if user modified parameters during rest (so we preserve their changes for next set)
         if (_workoutState.value is WorkoutState.Resting) {


### PR DESCRIPTION
…ssion

Added session-level eccentric load state that persists when switching between exercises during a workout. Previously the slider would reset to 100% when selecting a new exercise without saved defaults.